### PR TITLE
Refactor and simplify codebase for readability and efficiency

### DIFF
--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/backup/BackupProxyClient.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/backup/BackupProxyClient.java
@@ -59,7 +59,7 @@ public class BackupProxyClient
 				);
 			}
 		}
-		catch (IOException | InterruptedException | URISyntaxException e)
+		catch (final IOException | InterruptedException | URISyntaxException e)
 		{
 			throw new BackupProxyRequestException("failed to upload backup", e);
 		}
@@ -106,7 +106,7 @@ public class BackupProxyClient
 				);
 			}
 		}
-		catch (IOException | InterruptedException | URISyntaxException e)
+		catch (final IOException | InterruptedException | URISyntaxException e)
 		{
 			throw new BackupProxyRequestException("failed to upload backup", e);
 		}

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/backup/StorageBackupManager.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/backup/StorageBackupManager.java
@@ -129,7 +129,7 @@ public class StorageBackupManager
 	{
 		final List<BackupListItem> backupList = this.client.listBackups();
 
-		if (backupList.size() == 0 || backupList.size() < keptBackupsCount)
+		if (backupList.isEmpty() || backupList.size() < keptBackupsCount)
 		{
 			return;
 		}

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/backup/StorageBackupManager.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/backup/StorageBackupManager.java
@@ -137,7 +137,7 @@ public class StorageBackupManager
 		final BackupListItem oldestBackup = backupList.stream()
 			.map(b -> Pair.of(Instant.parse(b.getName()), b))
 			.sorted((a, b) -> b.left().compareTo(a.left()))
-			.map(b -> b.right())
+			.map(Pair::right)
 			.findFirst()
 			.get();
 

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/ClusterStorageBinaryDataDistributorKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/ClusterStorageBinaryDataDistributorKafka.java
@@ -124,8 +124,8 @@ public interface ClusterStorageBinaryDataDistributorKafka extends StorageBinaryD
 
 				final long offset = this.storageOffset.incrementAndGet();
 				record.headers().add("storageOffset", Long.toString(offset).getBytes(StandardCharsets.UTF_8));
-
-				producer.send(record);
+				
+				this.producer.send(record);
 
 				packetIndex++;
 			}

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/MyStorageBinaryDataClientKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/MyStorageBinaryDataClientKafka.java
@@ -199,17 +199,15 @@ public class MyStorageBinaryDataClientKafka implements StorageBinaryDataClientKa
 	private void consume(final ConsumerRecords<String, byte[]> records)
 	{
 		final List<StorageBinaryDataPacket> packets = new ArrayList<>();
-		final Iterator<ConsumerRecord<String, byte[]>> iterator = records.iterator();
-		while (iterator.hasNext())
+		for(final ConsumerRecord<String, byte[]> record : records)
 		{
-			final ConsumerRecord<String, byte[]> record = iterator.next();
-			if (record.serializedValueSize() >= 0)
+			if(record.serializedValueSize() >= 0)
 			{
 				final Headers headers = record.headers();
 				final long offset = Long.parseLong(
 					new String(headers.lastHeader("storageOffset").value(), StandardCharsets.UTF_8)
 				);
-				if (offset > this.storageOffset.get())
+				if(offset > this.storageOffset.get())
 				{
 					this.storageOffset.set(offset);
 					packets.add(this.createDataPacket(record, headers));

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/MyStorageBinaryDataClientKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/MyStorageBinaryDataClientKafka.java
@@ -28,12 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -142,7 +137,7 @@ public class MyStorageBinaryDataClientKafka implements StorageBinaryDataClientKa
 
 		try (final KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(properties))
 		{
-			consumer.subscribe(Arrays.asList(this.topicName));
+			consumer.subscribe(Collections.singletonList(this.topicName));
 			while (this.active.get())
 			{
 				if (!this.stopAtLatestOffset)

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/MyStorageBinaryDistributedKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/storage/MyStorageBinaryDistributedKafka.java
@@ -23,37 +23,37 @@ import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataMessage.M
 
 public class MyStorageBinaryDistributedKafka
 {
-	public final static String keyMessageType()
+	public static String keyMessageType()
 	{
 		return "message-type";
 	}
 
-	public final static String keyMessageLength()
+	public static String keyMessageLength()
 	{
 		return "message-length";
 	}
 
-	public final static String keyPacketCount()
+	public static String keyPacketCount()
 	{
 		return "packet-count";
 	}
 
-	public final static String keyPacketIndex()
+	public static String keyPacketIndex()
 	{
 		return "packet-index";
 	}
 
-	public final static int maxPacketSize()
+	public static int maxPacketSize()
 	{
 		return 1_000_000;
 	}
 
-	public final static Charset charset()
+	public static Charset charset()
 	{
 		return StandardCharsets.UTF_8;
 	}
 
-	public final static void addPacketHeaders(
+	public static void addPacketHeaders(
 		final Headers headers,
 		final MessageType messageType,
 		final int messageLength,
@@ -67,44 +67,44 @@ public class MyStorageBinaryDistributedKafka
 		headers.add(keyPacketCount(), serialize(packetCount));
 	}
 
-	public final static MessageType messageType(final Headers headers)
+	public static MessageType messageType(final Headers headers)
 	{
 		return MessageType.valueOf(deserializeString(headers.lastHeader(keyMessageType()).value()));
 	}
 
-	public final static int messageLength(final Headers headers)
+	public static int messageLength(final Headers headers)
 	{
 		return deserializeInt(headers.lastHeader(keyMessageLength()).value());
 	}
 
-	public final static int packetIndex(final Headers headers)
+	public static int packetIndex(final Headers headers)
 	{
 		return deserializeInt(headers.lastHeader(keyPacketIndex()).value());
 	}
 
-	public final static int packetCount(final Headers headers)
+	public static int packetCount(final Headers headers)
 	{
 		return deserializeInt(headers.lastHeader(keyPacketCount()).value());
 	}
 
-	public final static byte[] serialize(final String value)
+	public static byte[] serialize(final String value)
 	{
 		return value.getBytes(charset());
 	}
 
-	public final static String deserializeString(final byte[] bytes)
+	public static String deserializeString(final byte[] bytes)
 	{
 		return new String(bytes, charset());
 	}
 
-	public final static byte[] serialize(final int value)
+	public static byte[] serialize(final int value)
 	{
 		return new byte[] {
 			(byte)(value >>> 24), (byte)(value >>> 16), (byte)(value >>> 8), (byte)value
 		};
 	}
 
-	public final static int deserializeInt(final byte[] bytes)
+	public static int deserializeInt(final byte[] bytes)
 	{
 		int value = 0;
 		for (final byte b : bytes)

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
@@ -78,7 +78,7 @@ public final class GzipUtils
 
 			while ((entry = tarIn.getNextEntry()) != null)
 			{
-				/** If the entry is a directory, create the directory. **/
+				/* If the entry is a directory, create the directory. */
 				if (entry.isDirectory())
 				{
 					final File f = Paths.get("/storage", entry.getName()).toFile();

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
@@ -42,9 +42,9 @@ public final class GzipUtils
 	public static void compressTarGzip(final Path inputPath, final Path outputFile) throws ArchiveException
 	{
 		try (
-			OutputStream outputStream = Files.newOutputStream(outputFile);
-			GzipCompressorOutputStream gzipOut = new GzipCompressorOutputStream(outputStream);
-			TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut);
+			final OutputStream outputStream = Files.newOutputStream(outputFile);
+			final GzipCompressorOutputStream gzipOut = new GzipCompressorOutputStream(outputStream);
+			final TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut);
 			final Stream<Path> walk = Files.walk(inputPath)
 		)
 		{
@@ -71,7 +71,7 @@ public final class GzipUtils
 
 	public static void extractTarGZ(final InputStream in) throws IOException
 	{
-		try (TarArchiveInputStream tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(in)))
+		try (final TarArchiveInputStream tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(in)))
 		{
 			final int bufferSize = 1024;
 			TarArchiveEntry entry;
@@ -106,7 +106,7 @@ public final class GzipUtils
 						entry.getName().replaceFirst("storage", "/storage"),
 						false
 					);
-					try (BufferedOutputStream dest = new BufferedOutputStream(fos, bufferSize))
+					try (final BufferedOutputStream dest = new BufferedOutputStream(fos, bufferSize))
 					{
 						while ((count = tarIn.read(data, 0, bufferSize)) != -1)
 						{

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
@@ -94,7 +94,7 @@ public final class GzipUtils
 				else
 				{
 					int count;
-					final byte data[] = new byte[bufferSize];
+					final byte[] data = new byte[bufferSize];
 
 					final String parent = new File(entry.getName().replaceFirst("storage", "/storage")).getParent();
 					if (parent != null)

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/common/util/GzipUtils.java
@@ -76,7 +76,7 @@ public final class GzipUtils
 			final int bufferSize = 1024;
 			TarArchiveEntry entry;
 
-			while ((entry = (TarArchiveEntry)tarIn.getNextEntry()) != null)
+			while ((entry = tarIn.getNextEntry()) != null)
 			{
 				/** If the entry is a directory, create the directory. **/
 				if (entry.isDirectory())

--- a/storage/distributed/distributed/src/main/java/org/eclipse/datagrid/storage/distributed/types/StorageBinaryDataMerger.java
+++ b/storage/distributed/distributed/src/main/java/org/eclipse/datagrid/storage/distributed/types/StorageBinaryDataMerger.java
@@ -110,7 +110,7 @@ public interface StorageBinaryDataMerger extends StorageBinaryDataReceiver
 				final PersistenceTypeDefinition localType = localTypeDictionary .lookupTypeById(remoteType.typeId());
 				if(localType == null)
 				{
-					logger.debug("New type: " + remoteType.typeName());
+					logger.debug("New type: {}", remoteType.typeName());
 					this.foundation.getTypeHandlerManager().ensureTypeHandler(remoteType);
 					
 				}

--- a/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDataClientKafka.java
+++ b/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDataClientKafka.java
@@ -129,10 +129,9 @@ public interface StorageBinaryDataClientKafka extends StorageBinaryDataClient
 		private void consume(final ConsumerRecords<String, byte[]> records)
 		{
 			final List<StorageBinaryDataPacket>            packets  = new ArrayList<>();
-			final Iterator<ConsumerRecord<String, byte[]>> iterator   = records.iterator();
-			while(iterator.hasNext())
+			for(final ConsumerRecord<String, byte[]> record : records)
 			{
-				packets.add(this.createDataPacket(iterator.next()));
+				packets.add(this.createDataPacket(record));
 			}
 			if(!packets.isEmpty())
 			{

--- a/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDataClientKafka.java
+++ b/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDataClientKafka.java
@@ -19,11 +19,7 @@ import static org.eclipse.serializer.util.X.notNull;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -117,7 +113,7 @@ public interface StorageBinaryDataClientKafka extends StorageBinaryDataClient
 			
 			try(final KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(properties))
 			{
-				consumer.subscribe(Arrays.asList(this.topicName));
+				consumer.subscribe(Collections.singletonList(this.topicName));
 				while(this.active.get())
 				{
 					this.consume(consumer.poll(Duration.ofMillis(Long.MAX_VALUE)));

--- a/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDistributedKafka.java
+++ b/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDistributedKafka.java
@@ -23,42 +23,42 @@ import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataMessage.M
 
 final class StorageBinaryDistributedKafka
 {
-	final static String keyMessageType()
+	static String keyMessageType()
 	{
 		return "message-type";
 	}
 	
-	final static String keyMessageLength()
+	static String keyMessageLength()
 	{
 		return "message-length";
 	}
 	
-	final static String keyPacketCount()
+	static String keyPacketCount()
 	{
 		return "packet-count";
 	}
 	
-	final static String keyPacketIndex()
+	static String keyPacketIndex()
 	{
 		return "packet-index";
 	}
 	
-	final static int maxPacketSize()
+	static int maxPacketSize()
 	{
 		return 1_000_000;
 	}
 	
-	final static Charset charset()
+	static Charset charset()
 	{
 		return StandardCharsets.UTF_8;
 	}
 	
-	final static void addPacketHeaders(
-		final Headers     headers    ,
+	static void addPacketHeaders(
+		final Headers headers,
 		final MessageType messageType,
-		final int         messageLength,
-		final int         packetIndex,
-		final int         packetCount
+		final int messageLength,
+		final int packetIndex,
+		final int packetCount
 	)
 	{
 		headers.add(keyMessageType(),   serialize(messageType.name()));
@@ -67,39 +67,39 @@ final class StorageBinaryDistributedKafka
 		headers.add(keyPacketCount(),   serialize(packetCount));
 	}
 	
-	final static MessageType messageType(final Headers headers)
+	static MessageType messageType(final Headers headers)
 	{
 		return MessageType.valueOf(
 			deserializeString(headers.lastHeader(keyMessageType()).value())
 		);
 	}
 	
-	final static int messageLength(final Headers headers)
+	static int messageLength(final Headers headers)
 	{
 		return deserializeInt(headers.lastHeader(keyMessageLength()).value());
 	}
 	
-	final static int packetIndex(final Headers headers)
+	static int packetIndex(final Headers headers)
 	{
 		return deserializeInt(headers.lastHeader(keyPacketIndex()).value());
 	}
 	
-	final static int packetCount(final Headers headers)
+	static int packetCount(final Headers headers)
 	{
 		return deserializeInt(headers.lastHeader(keyPacketCount()).value());
 	}
 	
-	final static byte[] serialize(final String value)
+	static byte[] serialize(final String value)
 	{
 		return value.getBytes(charset());
 	}
 	
-	final static String deserializeString(final byte[] bytes)
+	static String deserializeString(final byte[] bytes)
 	{
 		return new String(bytes, charset());
 	}
 	
-	final static byte[] serialize(final int value)
+	static byte[] serialize(final int value)
 	{
 		return new byte[]
 		{
@@ -110,7 +110,7 @@ final class StorageBinaryDistributedKafka
 		};
 	}
 	
-	final static int deserializeInt(final byte[] bytes)
+	static int deserializeInt(final byte[] bytes)
 	{
 		int value = 0;
         for (final byte b : bytes) {


### PR DESCRIPTION
### Changes Proposed

This pull request includes several code quality improvements aimed at increasing readability, reducing redundancy, and aligning with best practices:
- Normalized commenting style in `GzipUtils`.
- Removed redundant casts in `GzipUtils` loop.
- Replaced `Arrays.asList` with `Collections.singletonList` in Kafka consumer subscriptions for simplicity.
- Used parameterized logging instead of string concatenation.
- Refactored usage of iterators to enhanced `for` loops.
- Simplified calls to `map` by using method references.
- Applied `.isEmpty()` for list size checks.
- Qualified local variables and specific references with `final` for clarity.
- Fixed array declaration syntax in `GzipUtils`.
- Removed unnecessary `final` modifiers from `static` methods.
