### PR TITLE
Limit data merger's cached data

### DIFF
--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterFoundation.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterFoundation.java
@@ -1,5 +1,13 @@
 package org.eclipse.datagrid.cluster.nodelibrary.types;
 
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.function.Supplier;
+
 /*-
  * #%L
  * Eclipse Data Grid Cluster Nodelibrary
@@ -15,14 +23,16 @@ package org.eclipse.datagrid.cluster.nodelibrary.types;
  */
 
 import org.eclipse.datagrid.cluster.nodelibrary.exceptions.NodelibraryException;
-import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.*;
+import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.GcWorkaroundQuartzCronJobManager;
 import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.GcWorkaroundQuartzCronJobManager.GcWorkaroundQuartzCronJob;
+import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.QuartzCronJobJobFactory;
+import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.QuartzCronJobScheduler;
+import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.StorageBackupQuartzCronJobManager;
 import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.StorageBackupQuartzCronJobManager.StorageBackupQuartzCronJob;
+import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.StorageLimitCheckerQuartzCronJobManager;
 import org.eclipse.datagrid.cluster.nodelibrary.types.cronjob.StorageLimitCheckerQuartzCronJobManager.StorageLimitCheckerQuartzCronJob;
 import org.eclipse.datagrid.storage.distributed.types.DistributedStorage;
 import org.eclipse.datagrid.storage.distributed.types.ObjectGraphUpdateHandler;
-import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataMerger;
-import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataPacketAcceptor;
 import org.eclipse.serializer.exceptions.MissingFoundationPartException;
 import org.eclipse.serializer.persistence.types.Unpersistable;
 import org.eclipse.serializer.reference.Lazy;
@@ -33,148 +43,144 @@ import org.eclipse.store.storage.exceptions.StorageException;
 import org.eclipse.store.storage.types.StorageConfiguration;
 import org.eclipse.store.storage.types.StorageExceptionHandler;
 import org.eclipse.store.storage.types.StorageLiveFileProvider;
-import org.quartz.*;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Comparator;
-import java.util.function.Supplier;
-
-
 public interface ClusterFoundation<F extends ClusterFoundation<?>> extends InstanceDispatcher
 {
-    StorageBackupBackend getStorageBackupBackend();
+	StorageBackupBackend getStorageBackupBackend();
 
-    F setStorageBackupBackend(StorageBackupBackend backend);
+	F setStorageBackupBackend(StorageBackupBackend backend);
 
-    StorageTaskExecutor getStorageTaskExecutor();
+	StorageTaskExecutor getStorageTaskExecutor();
 
-    F setStorageTaskExecutor(StorageTaskExecutor executor);
+	F setStorageTaskExecutor(StorageTaskExecutor executor);
 
-    StorageBackupTaskExecutor getStorageBackupTaskExecutor();
+	StorageBackupTaskExecutor getStorageBackupTaskExecutor();
 
-    F setStorageBackupTaskExecutor(StorageBackupTaskExecutor executor);
+	F setStorageBackupTaskExecutor(StorageBackupTaskExecutor executor);
 
-    BackupProxyHttpClient getBackupProxyHttpClient();
+	BackupProxyHttpClient getBackupProxyHttpClient();
 
-    F setBackupProxyHttpClient(BackupProxyHttpClient client);
+	F setBackupProxyHttpClient(BackupProxyHttpClient client);
 
-    QuartzCronJobScheduler getQuartzCronJobScheduler();
+	QuartzCronJobScheduler getQuartzCronJobScheduler();
 
-    F setQuartzCronJobScheduler(QuartzCronJobScheduler scheduler);
+	F setQuartzCronJobScheduler(QuartzCronJobScheduler scheduler);
 
-    QuartzCronJobJobFactory getQuartzCronJobJobFactory();
+	QuartzCronJobJobFactory getQuartzCronJobJobFactory();
 
-    F setQuartzCronJobJobFactory(QuartzCronJobJobFactory factory);
+	F setQuartzCronJobJobFactory(QuartzCronJobJobFactory factory);
 
-    StorageBackupQuartzCronJobManager getStorageBackupQuartzCronJobManager();
+	StorageBackupQuartzCronJobManager getStorageBackupQuartzCronJobManager();
 
-    F setStorageBackupQuartzCronJobManager(StorageBackupQuartzCronJobManager manager);
+	F setStorageBackupQuartzCronJobManager(StorageBackupQuartzCronJobManager manager);
 
-    StorageLimitCheckerQuartzCronJobManager getStorageLimitCheckerQuartzCronJobManager();
+	StorageLimitCheckerQuartzCronJobManager getStorageLimitCheckerQuartzCronJobManager();
 
-    F setStorageLimitCheckerQuartzCronJobManager(StorageLimitCheckerQuartzCronJobManager manager);
+	F setStorageLimitCheckerQuartzCronJobManager(StorageLimitCheckerQuartzCronJobManager manager);
 
-    GcWorkaroundQuartzCronJobManager getGcWorkaroundQuartzCronJobManager();
+	GcWorkaroundQuartzCronJobManager getGcWorkaroundQuartzCronJobManager();
 
-    F setGcWorkaroundQuartzCronJobManager(GcWorkaroundQuartzCronJobManager manager);
+	F setGcWorkaroundQuartzCronJobManager(GcWorkaroundQuartzCronJobManager manager);
 
-    KafkaPropertiesProvider getKafkaPropertiesProvider();
+	KafkaPropertiesProvider getKafkaPropertiesProvider();
 
-    F setKafkaPropertiesProvider(KafkaPropertiesProvider provider);
+	F setKafkaPropertiesProvider(KafkaPropertiesProvider provider);
 
-    ClusterStorageBinaryDataPacketAcceptor getClusterStorageBinaryDataPacketAcceptor();
+	ClusterStorageBinaryDataPacketAcceptor getClusterStorageBinaryDataPacketAcceptor();
 
-    F setClusterStorageBinaryDataPacketAcceptor(ClusterStorageBinaryDataPacketAcceptor acceptor);
+	F setClusterStorageBinaryDataPacketAcceptor(ClusterStorageBinaryDataPacketAcceptor acceptor);
 
-    ClusterStorageBinaryDataMerger getClusterStorageBinaryDataMerger();
+	ClusterStorageBinaryDataMerger getClusterStorageBinaryDataMerger();
 
-    F setClusterStorageBinaryDataMerger(ClusterStorageBinaryDataMerger merger);
+	F setClusterStorageBinaryDataMerger(ClusterStorageBinaryDataMerger merger);
 
-    AfterDataMessageConsumedListener getAfterDataMessageConsumedListener();
+	AfterDataMessageConsumedListener getAfterDataMessageConsumedListener();
 
-    F setAfterDataMessageConsumedListener(AfterDataMessageConsumedListener listener);
+	F setAfterDataMessageConsumedListener(AfterDataMessageConsumedListener listener);
 
     StoredMessageIndexManager getStoredMessageIndexManager();
 
     F setStoredMessageIndexManager(StoredMessageIndexManager manager);
 
-    StorageBackupManager getStorageBackupManager();
+	StorageBackupManager getStorageBackupManager();
 
-    F setStorageBackupManager(StorageBackupManager manager);
+	F setStorageBackupManager(StorageBackupManager manager);
 
-    Supplier<Object> getRootSupplier();
+	Supplier<Object> getRootSupplier();
 
-    F setRootSupplier(Supplier<Object> supplier);
+	F setRootSupplier(Supplier<Object> supplier);
 
-    ObjectGraphUpdateHandler getObjectGraphUpdateHandler();
+	ObjectGraphUpdateHandler getObjectGraphUpdateHandler();
 
-    F setObjectGraphUpdateHandler(ObjectGraphUpdateHandler handler);
+	F setObjectGraphUpdateHandler(ObjectGraphUpdateHandler handler);
 
-    EmbeddedStorageFoundation<?> getEmbeddedStorageFoundation();
+	EmbeddedStorageFoundation<?> getEmbeddedStorageFoundation();
 
-    F setEmbeddedStorageFoundation(EmbeddedStorageFoundation<?> foundation);
+	F setEmbeddedStorageFoundation(EmbeddedStorageFoundation<?> foundation);
 
-    BackupNodeManager getBackupNodeManager();
+	BackupNodeManager getBackupNodeManager();
 
-    F setBackupNodeManager(BackupNodeManager manager);
+	F setBackupNodeManager(BackupNodeManager manager);
 
-    ClusterStorageBinaryDataClient getClusterStorageBinaryDataClient();
+	ClusterStorageBinaryDataClient getClusterStorageBinaryDataClient();
 
-    F setClusterStorageBinaryDataClient(ClusterStorageBinaryDataClient client);
+	F setClusterStorageBinaryDataClient(ClusterStorageBinaryDataClient client);
 
-    ClusterStorageBinaryDataDistributor getClusterStorageBinaryDataDistributor();
+	ClusterStorageBinaryDataDistributor getClusterStorageBinaryDataDistributor();
 
-    F setClusterStorageBinaryDataDistributor(ClusterStorageBinaryDataDistributor distributor);
+	F setClusterStorageBinaryDataDistributor(ClusterStorageBinaryDataDistributor distributor);
 
-    MicroNodeManager getMicroNodeManager();
+	MicroNodeManager getMicroNodeManager();
 
-    F setMicroNodeManager(MicroNodeManager manager);
+	F setMicroNodeManager(MicroNodeManager manager);
 
-    StorageNodeHealthCheck getStorageNodeHealthCheck();
+	StorageNodeHealthCheck getStorageNodeHealthCheck();
 
-    F setStorageNodeHealthCheck(StorageNodeHealthCheck check);
+	F setStorageNodeHealthCheck(StorageNodeHealthCheck check);
 
-    NodelibraryPropertiesProvider getNodelibraryPropertiesProvider();
+	NodelibraryPropertiesProvider getNodelibraryPropertiesProvider();
 
-    F setNodelibraryPropertiesProvider(NodelibraryPropertiesProvider provider);
+	F setNodelibraryPropertiesProvider(NodelibraryPropertiesProvider provider);
 
-    StorageDiskSpaceReader getStorageDiskSpaceReader();
+	StorageDiskSpaceReader getStorageDiskSpaceReader();
 
-    F setStorageDiskSpaceReader(StorageDiskSpaceReader reader);
+	F setStorageDiskSpaceReader(StorageDiskSpaceReader reader);
 
-    StorageNodeManager getStorageNodeManager();
+	StorageNodeManager getStorageNodeManager();
 
-    F setStorageNodeManager(StorageNodeManager manager);
+	F setStorageNodeManager(StorageNodeManager manager);
 
-    boolean getEnableAsyncDistribution();
+	boolean getEnableAsyncDistribution();
 
-    F setEnableAsyncDistribution(boolean enable);
+	F setEnableAsyncDistribution(boolean enable);
 
     KafkaMessageInfoProvider getKafkaMessageInfoProvider();
 
     F setKafkaMessageInfoProvider(KafkaMessageInfoProvider provider);
 
-    static ClusterFoundation<?> New()
-    {
-        return new Default<>();
-    }
+	static ClusterFoundation<?> New()
+	{
+		return new Default<>();
+	}
 
-    ClusterRestRequestController startController() throws NodelibraryException;
+	ClusterRestRequestController startController() throws NodelibraryException;
 
-    ClusterStorageManager<?> startStorageManager() throws NodelibraryException;
+	ClusterStorageManager<?> startStorageManager() throws NodelibraryException;
 
-    class Default<F extends Default<?>> extends InstanceDispatcher.Default implements
-        ClusterFoundation<F>,
-        Unpersistable
-    {
-        private static final Logger LOG = LoggerFactory.getLogger(ClusterFoundation.class);
+	class Default<F extends Default<?>> extends InstanceDispatcher.Default implements
+		ClusterFoundation<F>,
+		Unpersistable
+	{
+		private static final Logger LOG = LoggerFactory.getLogger(ClusterFoundation.class);
 
         private StorageBackupBackend backupBackend;
         private BackupProxyHttpClient backupProxyHttpClient;
@@ -205,19 +211,19 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
         private KafkaPropertiesProvider kafkaPropertiesProvider;
         private KafkaMessageInfoProvider kafkaMessageInfoProvider;
 
-        // cached created types
-        private ClusterStorageManager<?> clusterStorageManager;
-        private ClusterRestRequestController clusterRequestController;
+		// cached created types
+		private ClusterStorageManager<?> clusterStorageManager;
+		private ClusterRestRequestController clusterRequestController;
 
-        private Default()
-        {
-        }
+		private Default()
+		{
+		}
 
-        @SuppressWarnings("unchecked")
-        protected final F $()
-        {
-            return (F)this;
-        }
+		@SuppressWarnings("unchecked")
+		protected final F $()
+		{
+			return (F)this;
+		}
 
         protected StorageBackupBackend ensureBackupBackend()
         {
@@ -251,79 +257,79 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             }
         }
 
-        protected StorageTaskExecutor ensureStorageTaskExecutor()
-        {
-            if (this.getNodelibraryPropertiesProvider().isBackupNode())
-            {
-                return this.getStorageBackupTaskExecutor();
-            }
-            return StorageTaskExecutor.New(this.clusterStorageManager);
-        }
+		protected StorageTaskExecutor ensureStorageTaskExecutor()
+		{
+			if (this.getNodelibraryPropertiesProvider().isBackupNode())
+			{
+				return this.getStorageBackupTaskExecutor();
+			}
+			return StorageTaskExecutor.New(this.clusterStorageManager);
+		}
 
-        protected StorageBackupTaskExecutor ensureStorageBackupTaskExecutor()
-        {
-            return StorageBackupTaskExecutor.New(this.clusterStorageManager, this.getStorageBackupManager());
-        }
+		protected StorageBackupTaskExecutor ensureStorageBackupTaskExecutor()
+		{
+			return StorageBackupTaskExecutor.New(this.clusterStorageManager, this.getStorageBackupManager());
+		}
 
-        protected StorageBackupQuartzCronJobManager ensureStorageBackupQuartzCronJobManager()
-        {
-            return StorageBackupQuartzCronJobManager.New(this.getStorageBackupManager());
-        }
+		protected StorageBackupQuartzCronJobManager ensureStorageBackupQuartzCronJobManager()
+		{
+			return StorageBackupQuartzCronJobManager.New(this.getStorageBackupManager());
+		}
 
-        protected BackupProxyHttpClient ensureBackupProxyHttpClient()
-        {
-            return BackupProxyHttpClient.New(
-                URI.create(this.getNodelibraryPropertiesProvider().backupProxyServiceUrl())
-            );
-        }
+		protected BackupProxyHttpClient ensureBackupProxyHttpClient()
+		{
+			return BackupProxyHttpClient.New(
+				URI.create(this.getNodelibraryPropertiesProvider().backupProxyServiceUrl())
+			);
+		}
 
-        protected QuartzCronJobJobFactory ensureCronJobFactory()
-        {
-            return QuartzCronJobJobFactory.New();
-        }
+		protected QuartzCronJobJobFactory ensureCronJobFactory()
+		{
+			return QuartzCronJobJobFactory.New();
+		}
 
-        protected QuartzCronJobScheduler ensureCronJobScheduler()
-        {
-            final Scheduler scheduler;
-            try
-            {
-                scheduler = StdSchedulerFactory.getDefaultScheduler();
-            }
-            catch (final SchedulerException e)
-            {
-                throw new NodelibraryException("Failed to get the default quartz cron job scheduler", e);
-            }
-            return QuartzCronJobScheduler.New(scheduler);
-        }
+		protected QuartzCronJobScheduler ensureCronJobScheduler()
+		{
+			final Scheduler scheduler;
+			try
+			{
+				scheduler = StdSchedulerFactory.getDefaultScheduler();
+			}
+			catch (final SchedulerException e)
+			{
+				throw new NodelibraryException("Failed to get the default quartz cron job scheduler", e);
+			}
+			return QuartzCronJobScheduler.New(scheduler);
+		}
 
-        protected GcWorkaroundQuartzCronJobManager ensureGcWorkaroundManager()
-        {
-            return GcWorkaroundQuartzCronJobManager.New(this.clusterStorageManager);
-        }
+		protected GcWorkaroundQuartzCronJobManager ensureGcWorkaroundManager()
+		{
+			return GcWorkaroundQuartzCronJobManager.New(this.clusterStorageManager);
+		}
 
-        protected StorageLimitCheckerQuartzCronJobManager ensureStorageLimitCheckerManager()
-        {
-            return StorageLimitCheckerQuartzCronJobManager.New(
-                this.getNodelibraryPropertiesProvider().storageLimitGB(),
-                this.getStorageDiskSpaceReader()
-            );
-        }
+		protected StorageLimitCheckerQuartzCronJobManager ensureStorageLimitCheckerManager()
+		{
+			return StorageLimitCheckerQuartzCronJobManager.New(
+				this.getNodelibraryPropertiesProvider().storageLimitGB(),
+				this.getStorageDiskSpaceReader()
+			);
+		}
 
         protected KafkaMessageInfoProvider ensureKafkaMessageInfoProvider()
         {
             final var nodelibProps = this.getNodelibraryPropertiesProvider();
             final var kafkaProps = this.getKafkaPropertiesProvider();
 
-            final String topic = nodelibProps.kafkaTopicName();
-            final String groupId = String.format("%s-%s-offsetgetter", topic, nodelibProps.myPodName());
+			final String topic = nodelibProps.kafkaTopicName();
+			final String groupId = String.format("%s-%s-offsetgetter", topic, nodelibProps.myPodName());
 
             return KafkaMessageInfoProvider.New(topic, groupId, kafkaProps);
         }
 
-        protected KafkaPropertiesProvider ensureKafkaPropertiesProvider()
-        {
-            return KafkaPropertiesProvider.New(this.getNodelibraryPropertiesProvider());
-        }
+		protected KafkaPropertiesProvider ensureKafkaPropertiesProvider()
+		{
+			return KafkaPropertiesProvider.New(this.getNodelibraryPropertiesProvider());
+		}
 
         protected StoredMessageIndexManager ensureStoredMessageIndexManager()
         {
@@ -333,9 +339,9 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             return StoredMessageIndexManager.New(NioFileSystem.New().ensureFile(messageInfoPath).tryUseWriting());
         }
 
-        protected AfterDataMessageConsumedListener ensureAfterDataMessageConsumedListener()
-        {
-            final var props = this.getNodelibraryPropertiesProvider();
+		protected AfterDataMessageConsumedListener ensureAfterDataMessageConsumedListener()
+		{
+			final var props = this.getNodelibraryPropertiesProvider();
 
             final var storedMessageInfoUpdater = new AfterDataMessageConsumedListener()
             {
@@ -364,15 +370,15 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             return storedMessageInfoUpdater;
         }
 
-        protected StorageBackupManager ensureStorageBackupManager()
-        {
-            final var props = this.getNodelibraryPropertiesProvider();
-            final int maxBackupCount = props.keptBackupsCount();
+		protected StorageBackupManager ensureStorageBackupManager()
+		{
+			final var props = this.getNodelibraryPropertiesProvider();
+			final int maxBackupCount = props.keptBackupsCount();
 
             final Supplier<MessageInfo> messageInfoProvider = this.getClusterStorageBinaryDataClient()::messageInfo;
 
-            return StorageBackupManager.New(
-                this.clusterStorageManager,
+			return StorageBackupManager.New(
+				this.clusterStorageManager,
 
                 maxBackupCount,
                 this.getStorageBackupBackend(),
@@ -381,32 +387,32 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             );
         }
 
-        protected Supplier<Object> ensureRootSupplier()
-        {
-            throw new MissingFoundationPartException(Supplier.class, "Missing root supplier");
-        }
+		protected Supplier<Object> ensureRootSupplier()
+		{
+			throw new MissingFoundationPartException(Supplier.class, "Missing root supplier");
+		}
 
-        protected ObjectGraphUpdateHandler ensureGraphUpdateHandler()
-        {
-            return ObjectGraphUpdateHandler.Synchronized();
-        }
+		protected ObjectGraphUpdateHandler ensureGraphUpdateHandler()
+		{
+			return ObjectGraphUpdateHandler.Synchronized();
+		}
 
-        protected EmbeddedStorageFoundation<?> ensureEmbeddedStorageFoundation()
-        {
-            return EmbeddedStorageFoundation.New();
-        }
+		protected EmbeddedStorageFoundation<?> ensureEmbeddedStorageFoundation()
+		{
+			return EmbeddedStorageFoundation.New();
+		}
 
-        protected BackupNodeManager ensureBackupNodeManager()
-        {
-            return BackupNodeManager.New(
-                this.getStorageBackupTaskExecutor(),
+		protected BackupNodeManager ensureBackupNodeManager()
+		{
+			return BackupNodeManager.New(
+				this.getStorageBackupTaskExecutor(),
 
-                this.getClusterStorageBinaryDataClient(),
-                this.getStorageBackupManager(),
-                this.clusterStorageManager,
-                this.getStorageDiskSpaceReader()
-            );
-        }
+				this.getClusterStorageBinaryDataClient(),
+				this.getStorageBackupManager(),
+				this.clusterStorageManager,
+				this.getStorageDiskSpaceReader()
+			);
+		}
 
         protected ClusterStorageBinaryDataClient ensureClusterStorageBinaryDataClient()
         {
@@ -437,42 +443,43 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             );
         }
 
-        protected MicroNodeManager ensureMicroNodeManager()
-        {
-            return MicroNodeManager.New(
-                this.getStorageTaskExecutor(),
-                this.clusterStorageManager,
-                this.getStorageBackupManager(),
-                this.getStorageDiskSpaceReader()
-            );
-        }
+		protected MicroNodeManager ensureMicroNodeManager()
+		{
+			return MicroNodeManager.New(
+				this.getStorageTaskExecutor(),
+				this.clusterStorageManager,
+				this.getStorageBackupManager(),
+				this.getStorageDiskSpaceReader()
+			);
+		}
 
-        protected StorageNodeHealthCheck ensureStorageNodeHealthCheck()
-        {
-            final var properties = this.getNodelibraryPropertiesProvider();
-            final var topic = properties.kafkaTopicName();
-            final var podName = properties.myPodName();
-            // TODO: Hardcoded
-            final var groupId = String.format("%s-%s-readiness", topic, podName);
-            return StorageNodeHealthCheck.New(
-                topic,
-                groupId,
-                this.clusterStorageManager,
-                this.getClusterStorageBinaryDataClient(),
-                this.getKafkaPropertiesProvider()
-            );
-        }
+		protected StorageNodeHealthCheck ensureStorageNodeHealthCheck()
+		{
+			final var properties = this.getNodelibraryPropertiesProvider();
+			final var topic = properties.kafkaTopicName();
+			final var podName = properties.myPodName();
+			// TODO: Hardcoded
+			final var groupId = String.format("%s-%s-readiness", topic, podName);
+			return StorageNodeHealthCheck.New(
+				topic,
+				groupId,
+				this.clusterStorageManager,
+				this.getClusterStorageBinaryDataClient(),
+				this.getKafkaPropertiesProvider()
+			);
+		}
 
-        protected NodelibraryPropertiesProvider ensureNodelibraryPropertiesProvider()
-        {
-            return NodelibraryPropertiesProvider.Env();
-        }
-        protected StorageDiskSpaceReader ensureStorageDiskSpaceReader()
-        {
-            return StorageDiskSpaceReader.New(
-                this.getEmbeddedStorageFoundation().getConfiguration().fileProvider().baseDirectory()
-            );
-        }
+		protected NodelibraryPropertiesProvider ensureNodelibraryPropertiesProvider()
+		{
+			return NodelibraryPropertiesProvider.Env();
+		}
+
+		protected StorageDiskSpaceReader ensureStorageDiskSpaceReader()
+		{
+			return StorageDiskSpaceReader.New(
+				this.getEmbeddedStorageFoundation().getConfiguration().fileProvider().baseDirectory()
+			);
+		}
 
         protected StorageNodeManager ensureStorageNodeManager()
         {
@@ -487,478 +494,484 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             );
         }
 
-        protected ClusterStorageBinaryDataDistributor ensureDataDistributor()
-        {
-            final var topic = this.getNodelibraryPropertiesProvider().kafkaTopicName();
-            final ClusterStorageBinaryDataDistributor delegate;
-            if (this.getEnableAsyncDistribution())
-            {
-                delegate = ClusterStorageBinaryDataDistributorKafka.Async(topic, this.getKafkaPropertiesProvider());
-                LOG.info("Using async kafka data distributor");
-            }
-            else
-            {
-                delegate = ClusterStorageBinaryDataDistributorKafka.Sync(topic, this.getKafkaPropertiesProvider());
-                LOG.info("Using sync kafka data distributor");
-            }
-            return ClusterStorageBinaryDataDistributor.Caching(delegate);
-        }
+		protected ClusterStorageBinaryDataDistributor ensureDataDistributor()
+		{
+			final var topic = this.getNodelibraryPropertiesProvider().kafkaTopicName();
+			final ClusterStorageBinaryDataDistributor delegate;
+			if (this.getEnableAsyncDistribution())
+			{
+				delegate = ClusterStorageBinaryDataDistributorKafka.Async(topic, this.getKafkaPropertiesProvider());
+				LOG.info("Using async kafka data distributor");
+			}
+			else
+			{
+				delegate = ClusterStorageBinaryDataDistributorKafka.Sync(topic, this.getKafkaPropertiesProvider());
+				LOG.info("Using sync kafka data distributor");
+			}
+			return ClusterStorageBinaryDataDistributor.Caching(delegate);
+		}
 
-        protected ClusterStorageBinaryDataMerger ensureClusterStorageBinaryDataMerger()
-        {
-            final Long mergerTimeoutMs = this.getNodelibraryPropertiesProvider().dataMergerTimeoutMs();
-            final long cachingTimeoutMs = mergerTimeoutMs == null ? ClusterStorageBinaryDataMerger.Defaults
-                .cachingTimeoutMs() : mergerTimeoutMs;
-            return ClusterStorageBinaryDataMerger.New(
-                this.getEmbeddedStorageFoundation().getConnectionFoundation(),
-                this.clusterStorageManager,
-                this.getObjectGraphUpdateHandler(),
-                cachingTimeoutMs
-            );
-        }
+		protected ClusterStorageBinaryDataMerger ensureClusterStorageBinaryDataMerger()
+		{
+			final Long cachingTimeoutMsNullable = this.getNodelibraryPropertiesProvider().dataMergerTimeoutMs();
+			final long cachingTimeoutMs = cachingTimeoutMsNullable == null ? ClusterStorageBinaryDataMerger.Defaults
+				.cachingTimeoutMs() : cachingTimeoutMsNullable;
 
-        protected ClusterStorageBinaryDataPacketAcceptor ensureDataPacketAcceptor()
-        {
-            return ClusterStorageBinaryDataPacketAcceptor.New(this.getClusterStorageBinaryDataMerger());
-        }
+			final Long cachedDataLimitNullable = this.getNodelibraryPropertiesProvider().dataMergerCachedDataLimit();
+			final long cachedDataLimit = cachedDataLimitNullable == null ? ClusterStorageBinaryDataMerger.Defaults
+				.cachingLimit() : cachedDataLimitNullable;
 
-        @Override
-        public StorageBackupBackend getStorageBackupBackend()
-        {
-            if (this.backupBackend == null)
-            {
-                this.backupBackend = this.dispatch(this.ensureBackupBackend());
-            }
-            return this.backupBackend;
-        }
+			return ClusterStorageBinaryDataMerger.New(
+				this.getEmbeddedStorageFoundation().getConnectionFoundation(),
+				this.clusterStorageManager,
+				this.getObjectGraphUpdateHandler(),
+				cachingTimeoutMs,
+				cachedDataLimit
+			);
+		}
 
-        @Override
-        public F setStorageBackupBackend(final StorageBackupBackend backend)
-        {
-            this.backupBackend = backend;
-            return this.$();
-        }
+		protected ClusterStorageBinaryDataPacketAcceptor ensureDataPacketAcceptor()
+		{
+			return ClusterStorageBinaryDataPacketAcceptor.New(this.getClusterStorageBinaryDataMerger());
+		}
 
-        @Override
-        public StorageTaskExecutor getStorageTaskExecutor()
-        {
-            if (this.storageTaskExecutor == null)
-            {
-                this.storageTaskExecutor = this.dispatch(this.ensureStorageTaskExecutor());
-            }
-            return this.storageTaskExecutor;
-        }
+		@Override
+		public StorageBackupBackend getStorageBackupBackend()
+		{
+			if (this.backupBackend == null)
+			{
+				this.backupBackend = this.dispatch(this.ensureBackupBackend());
+			}
+			return this.backupBackend;
+		}
 
-        @Override
-        public F setStorageTaskExecutor(final StorageTaskExecutor executor)
-        {
-            this.storageTaskExecutor = executor;
-            return this.$();
-        }
+		@Override
+		public F setStorageBackupBackend(final StorageBackupBackend backend)
+		{
+			this.backupBackend = backend;
+			return this.$();
+		}
 
-        @Override
-        public StorageBackupTaskExecutor getStorageBackupTaskExecutor()
-        {
-            if (this.storageBackupTaskExecutor == null)
-            {
-                this.storageBackupTaskExecutor = this.dispatch(this.ensureStorageBackupTaskExecutor());
-            }
-            return this.storageBackupTaskExecutor;
-        }
+		@Override
+		public StorageTaskExecutor getStorageTaskExecutor()
+		{
+			if (this.storageTaskExecutor == null)
+			{
+				this.storageTaskExecutor = this.dispatch(this.ensureStorageTaskExecutor());
+			}
+			return this.storageTaskExecutor;
+		}
 
-        @Override
-        public F setStorageBackupTaskExecutor(final StorageBackupTaskExecutor executor)
-        {
-            this.storageBackupTaskExecutor = executor;
-            return this.$();
-        }
+		@Override
+		public F setStorageTaskExecutor(final StorageTaskExecutor executor)
+		{
+			this.storageTaskExecutor = executor;
+			return this.$();
+		}
 
-        @Override
-        public StorageBackupQuartzCronJobManager getStorageBackupQuartzCronJobManager()
-        {
-            if (this.backupCronjobManager == null)
-            {
-                this.backupCronjobManager = this.dispatch(this.ensureStorageBackupQuartzCronJobManager());
-            }
-            return this.backupCronjobManager;
-        }
+		@Override
+		public StorageBackupTaskExecutor getStorageBackupTaskExecutor()
+		{
+			if (this.storageBackupTaskExecutor == null)
+			{
+				this.storageBackupTaskExecutor = this.dispatch(this.ensureStorageBackupTaskExecutor());
+			}
+			return this.storageBackupTaskExecutor;
+		}
 
-        @Override
-        public F setStorageBackupQuartzCronJobManager(final StorageBackupQuartzCronJobManager manager)
-        {
-            this.backupCronjobManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setStorageBackupTaskExecutor(final StorageBackupTaskExecutor executor)
+		{
+			this.storageBackupTaskExecutor = executor;
+			return this.$();
+		}
 
-        @Override
-        public BackupProxyHttpClient getBackupProxyHttpClient()
-        {
-            if (this.backupProxyHttpClient == null)
-            {
-                this.backupProxyHttpClient = this.dispatch(this.ensureBackupProxyHttpClient());
-            }
-            return this.backupProxyHttpClient;
-        }
+		@Override
+		public StorageBackupQuartzCronJobManager getStorageBackupQuartzCronJobManager()
+		{
+			if (this.backupCronjobManager == null)
+			{
+				this.backupCronjobManager = this.dispatch(this.ensureStorageBackupQuartzCronJobManager());
+			}
+			return this.backupCronjobManager;
+		}
 
-        @Override
-        public F setBackupProxyHttpClient(final BackupProxyHttpClient client)
-        {
-            this.backupProxyHttpClient = client;
-            return this.$();
-        }
+		@Override
+		public F setStorageBackupQuartzCronJobManager(final StorageBackupQuartzCronJobManager manager)
+		{
+			this.backupCronjobManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public QuartzCronJobJobFactory getQuartzCronJobJobFactory()
-        {
-            if (this.cronJobFactory == null)
-            {
-                this.cronJobFactory = this.dispatch(this.ensureCronJobFactory());
-            }
-            return this.cronJobFactory;
-        }
+		@Override
+		public BackupProxyHttpClient getBackupProxyHttpClient()
+		{
+			if (this.backupProxyHttpClient == null)
+			{
+				this.backupProxyHttpClient = this.dispatch(this.ensureBackupProxyHttpClient());
+			}
+			return this.backupProxyHttpClient;
+		}
 
-        @Override
-        public F setQuartzCronJobJobFactory(final QuartzCronJobJobFactory factory)
-        {
-            this.cronJobFactory = factory;
-            return this.$();
-        }
+		@Override
+		public F setBackupProxyHttpClient(final BackupProxyHttpClient client)
+		{
+			this.backupProxyHttpClient = client;
+			return this.$();
+		}
 
-        @Override
-        public QuartzCronJobScheduler getQuartzCronJobScheduler()
-        {
-            if (this.cronJobScheduler == null)
-            {
-                this.cronJobScheduler = this.dispatch(this.ensureCronJobScheduler());
-            }
-            return this.cronJobScheduler;
-        }
+		@Override
+		public QuartzCronJobJobFactory getQuartzCronJobJobFactory()
+		{
+			if (this.cronJobFactory == null)
+			{
+				this.cronJobFactory = this.dispatch(this.ensureCronJobFactory());
+			}
+			return this.cronJobFactory;
+		}
 
-        @Override
-        public F setQuartzCronJobScheduler(final QuartzCronJobScheduler scheduler)
-        {
-            this.cronJobScheduler = scheduler;
-            return this.$();
-        }
+		@Override
+		public F setQuartzCronJobJobFactory(final QuartzCronJobJobFactory factory)
+		{
+			this.cronJobFactory = factory;
+			return this.$();
+		}
 
-        @Override
-        public GcWorkaroundQuartzCronJobManager getGcWorkaroundQuartzCronJobManager()
-        {
-            if (this.gcWorkaroundManager == null)
-            {
-                this.gcWorkaroundManager = this.dispatch(this.ensureGcWorkaroundManager());
-            }
-            return this.gcWorkaroundManager;
-        }
+		@Override
+		public QuartzCronJobScheduler getQuartzCronJobScheduler()
+		{
+			if (this.cronJobScheduler == null)
+			{
+				this.cronJobScheduler = this.dispatch(this.ensureCronJobScheduler());
+			}
+			return this.cronJobScheduler;
+		}
 
-        @Override
-        public F setGcWorkaroundQuartzCronJobManager(final GcWorkaroundQuartzCronJobManager manager)
-        {
-            this.gcWorkaroundManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setQuartzCronJobScheduler(final QuartzCronJobScheduler scheduler)
+		{
+			this.cronJobScheduler = scheduler;
+			return this.$();
+		}
 
-        @Override
-        public StorageLimitCheckerQuartzCronJobManager getStorageLimitCheckerQuartzCronJobManager()
-        {
-            if (this.limitCheckerManager == null)
-            {
-                this.limitCheckerManager = this.dispatch(this.ensureStorageLimitCheckerManager());
-            }
-            return this.limitCheckerManager;
-        }
+		@Override
+		public GcWorkaroundQuartzCronJobManager getGcWorkaroundQuartzCronJobManager()
+		{
+			if (this.gcWorkaroundManager == null)
+			{
+				this.gcWorkaroundManager = this.dispatch(this.ensureGcWorkaroundManager());
+			}
+			return this.gcWorkaroundManager;
+		}
 
-        @Override
-        public F setStorageLimitCheckerQuartzCronJobManager(final StorageLimitCheckerQuartzCronJobManager manager)
-        {
-            this.limitCheckerManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setGcWorkaroundQuartzCronJobManager(final GcWorkaroundQuartzCronJobManager manager)
+		{
+			this.gcWorkaroundManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public KafkaPropertiesProvider getKafkaPropertiesProvider()
-        {
-            if (this.kafkaPropertiesProvider == null)
-            {
-                this.kafkaPropertiesProvider = this.dispatch(this.ensureKafkaPropertiesProvider());
-            }
-            return this.kafkaPropertiesProvider;
-        }
+		@Override
+		public StorageLimitCheckerQuartzCronJobManager getStorageLimitCheckerQuartzCronJobManager()
+		{
+			if (this.limitCheckerManager == null)
+			{
+				this.limitCheckerManager = this.dispatch(this.ensureStorageLimitCheckerManager());
+			}
+			return this.limitCheckerManager;
+		}
 
-        @Override
-        public F setKafkaPropertiesProvider(final KafkaPropertiesProvider provider)
-        {
-            this.kafkaPropertiesProvider = provider;
-            return this.$();
-        }
+		@Override
+		public F setStorageLimitCheckerQuartzCronJobManager(final StorageLimitCheckerQuartzCronJobManager manager)
+		{
+			this.limitCheckerManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public StorageBackupManager getStorageBackupManager()
-        {
-            if (this.storageBackupManager == null)
-            {
-                this.storageBackupManager = this.dispatch(this.ensureStorageBackupManager());
-            }
-            return this.storageBackupManager;
-        }
+		@Override
+		public KafkaPropertiesProvider getKafkaPropertiesProvider()
+		{
+			if (this.kafkaPropertiesProvider == null)
+			{
+				this.kafkaPropertiesProvider = this.dispatch(this.ensureKafkaPropertiesProvider());
+			}
+			return this.kafkaPropertiesProvider;
+		}
 
-        @Override
-        public F setStorageBackupManager(final StorageBackupManager manager)
-        {
-            this.storageBackupManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setKafkaPropertiesProvider(final KafkaPropertiesProvider provider)
+		{
+			this.kafkaPropertiesProvider = provider;
+			return this.$();
+		}
 
-        @Override
-        public ObjectGraphUpdateHandler getObjectGraphUpdateHandler()
-        {
-            if (this.graphUpdateHandler == null)
-            {
-                this.graphUpdateHandler = this.dispatch(this.ensureGraphUpdateHandler());
-            }
-            return this.graphUpdateHandler;
-        }
+		@Override
+		public StorageBackupManager getStorageBackupManager()
+		{
+			if (this.storageBackupManager == null)
+			{
+				this.storageBackupManager = this.dispatch(this.ensureStorageBackupManager());
+			}
+			return this.storageBackupManager;
+		}
 
-        @Override
-        public F setObjectGraphUpdateHandler(final ObjectGraphUpdateHandler handler)
-        {
-            this.graphUpdateHandler = handler;
-            return this.$();
-        }
+		@Override
+		public F setStorageBackupManager(final StorageBackupManager manager)
+		{
+			this.storageBackupManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public Supplier<Object> getRootSupplier()
-        {
-            if (this.rootSupplier == null)
-            {
-                this.rootSupplier = this.dispatch(this.ensureRootSupplier());
-            }
-            return this.rootSupplier;
-        }
+		@Override
+		public ObjectGraphUpdateHandler getObjectGraphUpdateHandler()
+		{
+			if (this.graphUpdateHandler == null)
+			{
+				this.graphUpdateHandler = this.dispatch(this.ensureGraphUpdateHandler());
+			}
+			return this.graphUpdateHandler;
+		}
 
-        @Override
-        public F setRootSupplier(final Supplier<Object> supplier)
-        {
-            this.rootSupplier = supplier;
-            return this.$();
-        }
+		@Override
+		public F setObjectGraphUpdateHandler(final ObjectGraphUpdateHandler handler)
+		{
+			this.graphUpdateHandler = handler;
+			return this.$();
+		}
 
-        @Override
-        public boolean getEnableAsyncDistribution()
-        {
-            return this.enableAsyncDistribution;
-        }
+		@Override
+		public Supplier<Object> getRootSupplier()
+		{
+			if (this.rootSupplier == null)
+			{
+				this.rootSupplier = this.dispatch(this.ensureRootSupplier());
+			}
+			return this.rootSupplier;
+		}
 
-        @Override
-        public F setEnableAsyncDistribution(final boolean enable)
-        {
-            this.enableAsyncDistribution = enable;
-            return this.$();
-        }
+		@Override
+		public F setRootSupplier(final Supplier<Object> supplier)
+		{
+			this.rootSupplier = supplier;
+			return this.$();
+		}
 
-        @Override
-        public EmbeddedStorageFoundation<?> getEmbeddedStorageFoundation()
-        {
-            if (this.embeddedStorageFoundation == null)
-            {
-                this.embeddedStorageFoundation = this.dispatch(this.ensureEmbeddedStorageFoundation());
-            }
-            return this.embeddedStorageFoundation;
-        }
+		@Override
+		public boolean getEnableAsyncDistribution()
+		{
+			return this.enableAsyncDistribution;
+		}
 
-        @Override
-        public F setEmbeddedStorageFoundation(final EmbeddedStorageFoundation<?> foundation)
-        {
-            this.embeddedStorageFoundation = foundation;
-            return this.$();
-        }
+		@Override
+		public F setEnableAsyncDistribution(final boolean enable)
+		{
+			this.enableAsyncDistribution = enable;
+			return this.$();
+		}
 
-        @Override
-        public BackupNodeManager getBackupNodeManager()
-        {
-            if (this.backupNodeManager == null)
-            {
-                this.backupNodeManager = this.dispatch(this.ensureBackupNodeManager());
-            }
-            return this.backupNodeManager;
-        }
+		@Override
+		public EmbeddedStorageFoundation<?> getEmbeddedStorageFoundation()
+		{
+			if (this.embeddedStorageFoundation == null)
+			{
+				this.embeddedStorageFoundation = this.dispatch(this.ensureEmbeddedStorageFoundation());
+			}
+			return this.embeddedStorageFoundation;
+		}
 
-        @Override
-        public F setBackupNodeManager(final BackupNodeManager manager)
-        {
-            this.backupNodeManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setEmbeddedStorageFoundation(final EmbeddedStorageFoundation<?> foundation)
+		{
+			this.embeddedStorageFoundation = foundation;
+			return this.$();
+		}
 
-        @Override
-        public ClusterStorageBinaryDataClient getClusterStorageBinaryDataClient()
-        {
-            if (this.dataClient == null)
-            {
-                this.dataClient = this.dispatch(this.ensureClusterStorageBinaryDataClient());
-            }
-            return this.dataClient;
-        }
+		@Override
+		public BackupNodeManager getBackupNodeManager()
+		{
+			if (this.backupNodeManager == null)
+			{
+				this.backupNodeManager = this.dispatch(this.ensureBackupNodeManager());
+			}
+			return this.backupNodeManager;
+		}
 
-        @Override
-        public F setClusterStorageBinaryDataClient(final ClusterStorageBinaryDataClient client)
-        {
-            this.dataClient = client;
-            return this.$();
-        }
+		@Override
+		public F setBackupNodeManager(final BackupNodeManager manager)
+		{
+			this.backupNodeManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public ClusterStorageBinaryDataDistributor getClusterStorageBinaryDataDistributor()
-        {
-            if (this.dataDistributor == null)
-            {
-                this.dataDistributor = this.dispatch(this.ensureDataDistributor());
-            }
-            return this.dataDistributor;
-        }
+		@Override
+		public ClusterStorageBinaryDataClient getClusterStorageBinaryDataClient()
+		{
+			if (this.dataClient == null)
+			{
+				this.dataClient = this.dispatch(this.ensureClusterStorageBinaryDataClient());
+			}
+			return this.dataClient;
+		}
 
-        @Override
-        public F setClusterStorageBinaryDataDistributor(final ClusterStorageBinaryDataDistributor distributor)
-        {
-            this.dataDistributor = distributor;
-            return this.$();
-        }
+		@Override
+		public F setClusterStorageBinaryDataClient(final ClusterStorageBinaryDataClient client)
+		{
+			this.dataClient = client;
+			return this.$();
+		}
 
-        @Override
-        public MicroNodeManager getMicroNodeManager()
-        {
-            if (this.microNodeManager == null)
-            {
-                this.microNodeManager = this.dispatch(this.ensureMicroNodeManager());
-            }
-            return this.microNodeManager;
-        }
+		@Override
+		public ClusterStorageBinaryDataDistributor getClusterStorageBinaryDataDistributor()
+		{
+			if (this.dataDistributor == null)
+			{
+				this.dataDistributor = this.dispatch(this.ensureDataDistributor());
+			}
+			return this.dataDistributor;
+		}
 
-        @Override
-        public F setMicroNodeManager(final MicroNodeManager manager)
-        {
-            this.microNodeManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setClusterStorageBinaryDataDistributor(final ClusterStorageBinaryDataDistributor distributor)
+		{
+			this.dataDistributor = distributor;
+			return this.$();
+		}
 
-        @Override
-        public StorageNodeHealthCheck getStorageNodeHealthCheck()
-        {
-            if (this.healthCheck == null)
-            {
-                this.healthCheck = this.dispatch(this.ensureStorageNodeHealthCheck());
-            }
-            return this.healthCheck;
-        }
+		@Override
+		public MicroNodeManager getMicroNodeManager()
+		{
+			if (this.microNodeManager == null)
+			{
+				this.microNodeManager = this.dispatch(this.ensureMicroNodeManager());
+			}
+			return this.microNodeManager;
+		}
 
-        @Override
-        public F setStorageNodeHealthCheck(final StorageNodeHealthCheck check)
-        {
-            this.healthCheck = check;
-            return this.$();
-        }
+		@Override
+		public F setMicroNodeManager(final MicroNodeManager manager)
+		{
+			this.microNodeManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public NodelibraryPropertiesProvider getNodelibraryPropertiesProvider()
-        {
-            if (this.propertiesProvider == null)
-            {
-                this.propertiesProvider = this.dispatch(this.ensureNodelibraryPropertiesProvider());
-            }
-            return this.propertiesProvider;
-        }
+		@Override
+		public StorageNodeHealthCheck getStorageNodeHealthCheck()
+		{
+			if (this.healthCheck == null)
+			{
+				this.healthCheck = this.dispatch(this.ensureStorageNodeHealthCheck());
+			}
+			return this.healthCheck;
+		}
 
-        @Override
-        public F setNodelibraryPropertiesProvider(final NodelibraryPropertiesProvider provider)
-        {
-            this.propertiesProvider = provider;
-            return this.$();
-        }
+		@Override
+		public F setStorageNodeHealthCheck(final StorageNodeHealthCheck check)
+		{
+			this.healthCheck = check;
+			return this.$();
+		}
 
-        @Override
-        public StorageDiskSpaceReader getStorageDiskSpaceReader()
-        {
-            if (this.storageDiskSpaceReader == null)
-            {
-                this.storageDiskSpaceReader = this.dispatch(this.ensureStorageDiskSpaceReader());
-            }
-            return this.storageDiskSpaceReader;
-        }
+		@Override
+		public NodelibraryPropertiesProvider getNodelibraryPropertiesProvider()
+		{
+			if (this.propertiesProvider == null)
+			{
+				this.propertiesProvider = this.dispatch(this.ensureNodelibraryPropertiesProvider());
+			}
+			return this.propertiesProvider;
+		}
 
-        @Override
-        public F setStorageDiskSpaceReader(final StorageDiskSpaceReader reader)
-        {
-            this.storageDiskSpaceReader = reader;
-            return this.$();
-        }
+		@Override
+		public F setNodelibraryPropertiesProvider(final NodelibraryPropertiesProvider provider)
+		{
+			this.propertiesProvider = provider;
+			return this.$();
+		}
 
-        @Override
-        public StorageNodeManager getStorageNodeManager()
-        {
-            if (this.storageNodeManager == null)
-            {
-                this.storageNodeManager = this.dispatch(this.ensureStorageNodeManager());
-            }
-            return this.storageNodeManager;
-        }
+		@Override
+		public StorageDiskSpaceReader getStorageDiskSpaceReader()
+		{
+			if (this.storageDiskSpaceReader == null)
+			{
+				this.storageDiskSpaceReader = this.dispatch(this.ensureStorageDiskSpaceReader());
+			}
+			return this.storageDiskSpaceReader;
+		}
 
-        @Override
-        public F setStorageNodeManager(final StorageNodeManager manager)
-        {
-            this.storageNodeManager = manager;
-            return this.$();
-        }
+		@Override
+		public F setStorageDiskSpaceReader(final StorageDiskSpaceReader reader)
+		{
+			this.storageDiskSpaceReader = reader;
+			return this.$();
+		}
 
-        @Override
-        public AfterDataMessageConsumedListener getAfterDataMessageConsumedListener()
-        {
-            if (this.afterDataMessageConsumedListener == null)
-            {
-                this.afterDataMessageConsumedListener = this.dispatch(this.ensureAfterDataMessageConsumedListener());
-            }
-            return this.afterDataMessageConsumedListener;
-        }
+		@Override
+		public StorageNodeManager getStorageNodeManager()
+		{
+			if (this.storageNodeManager == null)
+			{
+				this.storageNodeManager = this.dispatch(this.ensureStorageNodeManager());
+			}
+			return this.storageNodeManager;
+		}
 
-        @Override
-        public F setAfterDataMessageConsumedListener(final AfterDataMessageConsumedListener listener)
-        {
-            this.afterDataMessageConsumedListener = listener;
-            return this.$();
-        }
+		@Override
+		public F setStorageNodeManager(final StorageNodeManager manager)
+		{
+			this.storageNodeManager = manager;
+			return this.$();
+		}
 
-        @Override
-        public ClusterStorageBinaryDataMerger getClusterStorageBinaryDataMerger()
-        {
-            if (this.dataMerger == null)
-            {
-                this.dataMerger = this.dispatch(this.ensureClusterStorageBinaryDataMerger());
-            }
-            return this.dataMerger;
-        }
+		@Override
+		public AfterDataMessageConsumedListener getAfterDataMessageConsumedListener()
+		{
+			if (this.afterDataMessageConsumedListener == null)
+			{
+				this.afterDataMessageConsumedListener = this.dispatch(this.ensureAfterDataMessageConsumedListener());
+			}
+			return this.afterDataMessageConsumedListener;
+		}
 
-        @Override
-        public F setClusterStorageBinaryDataMerger(final ClusterStorageBinaryDataMerger merger)
-        {
-            this.dataMerger = merger;
-            return this.$();
-        }
+		@Override
+		public F setAfterDataMessageConsumedListener(final AfterDataMessageConsumedListener listener)
+		{
+			this.afterDataMessageConsumedListener = listener;
+			return this.$();
+		}
 
-        @Override
-        public ClusterStorageBinaryDataPacketAcceptor getClusterStorageBinaryDataPacketAcceptor()
-        {
-            if (this.dataPacketAcceptor == null)
-            {
-                this.dataPacketAcceptor = this.dispatch(this.ensureDataPacketAcceptor());
-            }
-            return this.dataPacketAcceptor;
-        }
+		@Override
+		public ClusterStorageBinaryDataMerger getClusterStorageBinaryDataMerger()
+		{
+			if (this.dataMerger == null)
+			{
+				this.dataMerger = this.dispatch(this.ensureClusterStorageBinaryDataMerger());
+			}
+			return this.dataMerger;
+		}
 
-        @Override
-        public F setClusterStorageBinaryDataPacketAcceptor(final ClusterStorageBinaryDataPacketAcceptor acceptor)
-        {
-            this.dataPacketAcceptor = acceptor;
-            return this.$();
-        }
+		@Override
+		public F setClusterStorageBinaryDataMerger(final ClusterStorageBinaryDataMerger merger)
+		{
+			this.dataMerger = merger;
+			return this.$();
+		}
+
+		@Override
+		public ClusterStorageBinaryDataPacketAcceptor getClusterStorageBinaryDataPacketAcceptor()
+		{
+			if (this.dataPacketAcceptor == null)
+			{
+				this.dataPacketAcceptor = this.dispatch(this.ensureDataPacketAcceptor());
+			}
+			return this.dataPacketAcceptor;
+		}
+
+		@Override
+		public F setClusterStorageBinaryDataPacketAcceptor(final ClusterStorageBinaryDataPacketAcceptor acceptor)
+		{
+			this.dataPacketAcceptor = acceptor;
+			return this.$();
+		}
 
         @Override
         public StoredMessageIndexManager getStoredMessageIndexManager()
@@ -994,81 +1007,81 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
             return this.$();
         }
 
-        @Override
-        public ClusterRestRequestController startController() throws NodelibraryException
-        {
-            if (this.clusterRequestController == null)
-            {
-                this.start();
-            }
+		@Override
+		public ClusterRestRequestController startController() throws NodelibraryException
+		{
+			if (this.clusterRequestController == null)
+			{
+				this.start();
+			}
 
-            return this.clusterRequestController;
-        }
+			return this.clusterRequestController;
+		}
 
-        @Override
-        public ClusterStorageManager<?> startStorageManager() throws NodelibraryException
-        {
-            if (this.clusterStorageManager == null)
-            {
-                this.start();
-            }
+		@Override
+		public ClusterStorageManager<?> startStorageManager() throws NodelibraryException
+		{
+			if (this.clusterStorageManager == null)
+			{
+				this.start();
+			}
 
-            return this.clusterStorageManager;
-        }
+			return this.clusterStorageManager;
+		}
 
-        protected void start() throws NodelibraryException
-        {
-            final var properties = this.getNodelibraryPropertiesProvider();
+		protected void start() throws NodelibraryException
+		{
+			final var properties = this.getNodelibraryPropertiesProvider();
 
-            if (!properties.isProdMode())
-            {
-                this.startDevNode();
-            }
-            else if (properties.isMicro())
-            {
-                this.startMicroNode();
-            }
-            else if (properties.isBackupNode())
-            {
-                this.startBackupNode();
-            }
-            else
-            {
-                this.startStorageNode();
-            }
-        }
+			if (!properties.isProdMode())
+			{
+				this.startDevNode();
+			}
+			else if (properties.isMicro())
+			{
+				this.startMicroNode();
+			}
+			else if (properties.isBackupNode())
+			{
+				this.startBackupNode();
+			}
+			else
+			{
+				this.startStorageNode();
+			}
+		}
 
-        protected void startBackupNode() throws NodelibraryException
-        {
-            LOG.info("Starting backup cluster node");
+		protected void startBackupNode() throws NodelibraryException
+		{
+			LOG.info("Starting backup cluster node");
 
             this.getKafkaMessageInfoProvider().init();
 
 
-            // TODO: Hardcoded paths
-            final var storageParentPath = Paths.get("/storage/");
-            final var storageRootPath = storageParentPath.resolve("storage");
+			// TODO: Hardcoded paths
+			final var storageParentPath = Paths.get("/storage/");
+			final var storageRootPath = storageParentPath.resolve("storage");
 
             // if we use a downloaded storage, always scroll to the latest message so we don't read old messages
             boolean useLatestMessageIndex = false;
             boolean requiresStorageUpload = false;
 
-            // don't send messages generated by starting the storage and storing the empty root
-            this.getClusterStorageBinaryDataDistributor().ignoreDistribution(true);
+			// don't send messages generated by starting the storage and storing the empty root
+			this.getClusterStorageBinaryDataDistributor().ignoreDistribution(true);
 
-            final var backend = this.getStorageBackupBackend();
+			final var backend = this.getStorageBackupBackend();
 
-            final boolean containsBackups = backend.containsBackups();
+			final boolean containsBackups = backend.containsBackups();
 
-            /*
-             * If there are backups already available, use those instead as a fresh cluster
-             * has none, but a upgraded cluster has the previous storage backed up
-             */
+			/*
+			 * If there are backups already available, use those instead as a fresh cluster
+			 * has none, but a upgraded cluster has the previous storage backed up
+			 */
 
-            // user uploaded a new storage
-            if (backend.hasUserUploadedStorage())
-            {
-                LOG.info("Downloading user uploaded storage");
+			// user uploaded a new storage
+			if (backend.hasUserUploadedStorage())
+			{
+				LOG.info("Downloading user uploaded storage");
 
                 useLatestMessageIndex = true;
                 // since the storage is now different than before the storage nodes
@@ -1095,108 +1108,108 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
                 this.getStoredMessageIndexManager().set(info);
             }
 
-            LOG.info("Creating nodelibrary cluster controller");
+			LOG.info("Creating nodelibrary cluster controller");
 
-            final var embeddedStorageFoundation = this.getEmbeddedStorageFoundation();
-            // replace the storage live file provider from the provided embedded storage foundation
-            StorageConfiguration storageConfig = embeddedStorageFoundation.getConfiguration();
-            storageConfig = StorageConfiguration.Builder()
-                .setBackupSetup(storageConfig.backupSetup())
-                .setChannelCountProvider(storageConfig.channelCountProvider())
-                .setDataFileEvaluator(storageConfig.dataFileEvaluator())
-                .setEntityCacheEvaluator(storageConfig.entityCacheEvaluator())
-                .setHousekeepingController(storageConfig.housekeepingController())
-                .setStorageFileProvider(
-                    StorageLiveFileProvider.New(NioFileSystem.New().ensureDirectory(storageRootPath))
-                )
-                .createConfiguration();
-            embeddedStorageFoundation.setConfiguration(storageConfig);
+			final var embeddedStorageFoundation = this.getEmbeddedStorageFoundation();
+			// replace the storage live file provider from the provided embedded storage foundation
+			StorageConfiguration storageConfig = embeddedStorageFoundation.getConfiguration();
+			storageConfig = StorageConfiguration.Builder()
+				.setBackupSetup(storageConfig.backupSetup())
+				.setChannelCountProvider(storageConfig.channelCountProvider())
+				.setDataFileEvaluator(storageConfig.dataFileEvaluator())
+				.setEntityCacheEvaluator(storageConfig.entityCacheEvaluator())
+				.setHousekeepingController(storageConfig.housekeepingController())
+				.setStorageFileProvider(
+					StorageLiveFileProvider.New(NioFileSystem.New().ensureDirectory(storageRootPath))
+				)
+				.createConfiguration();
+			embeddedStorageFoundation.setConfiguration(storageConfig);
 
-            embeddedStorageFoundation.setExceptionHandler((throwable, channel) ->
-            {
-                try
-                {
-                    StorageExceptionHandler.defaultHandleException(throwable, channel);
-                }
-                catch (final StorageException exception)
-                {
-                    GlobalErrorHandling.handleFatalError(exception);
-                }
-            });
+			embeddedStorageFoundation.setExceptionHandler((throwable, channel) ->
+			{
+				try
+				{
+					StorageExceptionHandler.defaultHandleException(throwable, channel);
+				}
+				catch (final StorageException exception)
+				{
+					GlobalErrorHandling.handleFatalError(exception);
+				}
+			});
 
-            final var embeddedStorageManager = embeddedStorageFoundation.start();
+			final var embeddedStorageManager = embeddedStorageFoundation.start();
 
-            if (embeddedStorageManager.root() == null)
-            {
-                LOG.debug("Setting and storing new root from root supplier");
-                final var root = this.getRootSupplier().get();
-                if (root instanceof Lazy)
-                {
-                    embeddedStorageManager.setRoot(root);
-                }
-                else
-                {
-                    embeddedStorageManager.setRoot(Lazy.Reference(root));
-                }
-                embeddedStorageManager.storeRoot();
-            }
+			if (embeddedStorageManager.root() == null)
+			{
+				LOG.debug("Setting and storing new root from root supplier");
+				final var root = this.getRootSupplier().get();
+				if (root instanceof Lazy)
+				{
+					embeddedStorageManager.setRoot(root);
+				}
+				else
+				{
+					embeddedStorageManager.setRoot(Lazy.Reference(root));
+				}
+				embeddedStorageManager.storeRoot();
+			}
 
-            this.getClusterStorageBinaryDataDistributor().ignoreDistribution(false);
+			this.getClusterStorageBinaryDataDistributor().ignoreDistribution(false);
 
-            final var scheduler = this.getQuartzCronJobScheduler();
+			final var scheduler = this.getQuartzCronJobScheduler();
 
-            this.clusterStorageManager = ClusterStorageManager.Wrapper(embeddedStorageManager, scheduler::shutdown);
+			this.clusterStorageManager = ClusterStorageManager.Wrapper(embeddedStorageManager, scheduler::shutdown);
 
-            this.getClusterStorageBinaryDataClient().start();
+			this.getClusterStorageBinaryDataClient().start();
 
-            this.clusterRequestController = ClusterRestRequestController.BackupNode(
-                this.getBackupNodeManager(),
-                this.getNodelibraryPropertiesProvider()
-            );
+			this.clusterRequestController = ClusterRestRequestController.BackupNode(
+				this.getBackupNodeManager(),
+				this.getNodelibraryPropertiesProvider()
+			);
 
-            final var jobFactory = this.getQuartzCronJobJobFactory();
-            scheduler.setFactory(jobFactory);
+			final var jobFactory = this.getQuartzCronJobJobFactory();
+			scheduler.setFactory(jobFactory);
 
-            final var gcWorkaround = this.getGcWorkaroundQuartzCronJobManager();
-            jobFactory.setJobFactory(GcWorkaroundQuartzCronJob.class, gcWorkaround::create);
-            scheduler.schedule(
-                JobBuilder.newJob(GcWorkaroundQuartzCronJob.class).withIdentity("GcWorkaround").build(),
-                // Once every 30 minutes
-                TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule("0 */30 * * * ? *")).build()
-            );
+			final var gcWorkaround = this.getGcWorkaroundQuartzCronJobManager();
+			jobFactory.setJobFactory(GcWorkaroundQuartzCronJob.class, gcWorkaround::create);
+			scheduler.schedule(
+				JobBuilder.newJob(GcWorkaroundQuartzCronJob.class).withIdentity("GcWorkaround").build(),
+				// Once every 30 minutes
+				TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule("0 */30 * * * ? *")).build()
+			);
 
-            final var storageBackup = this.getStorageBackupQuartzCronJobManager();
-            jobFactory.setJobFactory(StorageBackupQuartzCronJob.class, storageBackup::create);
-            scheduler.schedule(
-                JobBuilder.newJob(StorageBackupQuartzCronJob.class).withIdentity("StorageBackup").build(),
-                // Once at the start of every 2 hours
-                TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule("0 0 */2 * * ? *")).build()
-            );
+			final var storageBackup = this.getStorageBackupQuartzCronJobManager();
+			jobFactory.setJobFactory(StorageBackupQuartzCronJob.class, storageBackup::create);
+			scheduler.schedule(
+				JobBuilder.newJob(StorageBackupQuartzCronJob.class).withIdentity("StorageBackup").build(),
+				// Once at the start of every 2 hours
+				TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule("0 0 */2 * * ? *")).build()
+			);
 
-            // storage nodes need an initial backup to start from
-            if (requiresStorageUpload)
-            {
-                LOG.info("Uploading starter backup for storage nodes");
-                this.getBackupNodeManager().createStorageBackup(false);
-            }
+			// storage nodes need an initial backup to start from
+			if (requiresStorageUpload)
+			{
+				LOG.info("Uploading starter backup for storage nodes");
+				this.getBackupNodeManager().createStorageBackup(false);
+			}
 
-            scheduler.start();
-        }
+			scheduler.start();
+		}
 
-        protected void startStorageNode() throws NodelibraryException
-        {
-            LOG.info("Starting storage cluster node");
+		protected void startStorageNode() throws NodelibraryException
+		{
+			LOG.info("Starting storage cluster node");
 
             // TODO: Hardcoded paths
             final var storageParentPath = Paths.get("/storage/");
             final var storageRootPath = storageParentPath.resolve("storage");
             final var messageInfoPath = storageParentPath.resolve("offset");
 
-            if (Files.exists(storageRootPath))
-            {
-                LOG.info("Cleaning storage directory");
-                this.deleteDirectory(storageRootPath);
-            }
+			if (Files.exists(storageRootPath))
+			{
+				LOG.info("Cleaning storage directory");
+				this.deleteDirectory(storageRootPath);
+			}
 
             if (Files.exists(messageInfoPath))
             {
@@ -1210,303 +1223,262 @@ public interface ClusterFoundation<F extends ClusterFoundation<?>> extends Insta
                 }
             }
 
-            // don't send messages generated by starting the storage and storing the empty root
-            this.getClusterStorageBinaryDataDistributor().ignoreDistribution(true);
+			// don't send messages generated by starting the storage and storing the empty root
+			this.getClusterStorageBinaryDataDistributor().ignoreDistribution(true);
 
-            final var backend = this.getStorageBackupBackend();
-            final boolean containsBackups = backend.containsBackups();
+			final var backend = this.getStorageBackupBackend();
+			final boolean containsBackups = backend.containsBackups();
 
-            /*
-             * If there are backups already available, use those instead
-             */
+			/*
+			 * If there are backups already available, use those instead
+			 */
 
-            if (containsBackups)
-            {
-                LOG.info("Downloading latest storage backup");
-                backend.downloadLatestBackup(storageParentPath);
-            }
-            else
-            {
-                LOG.info("Starting with local storage");
-            }
+			if (containsBackups)
+			{
+				LOG.info("Downloading latest storage backup");
+				backend.downloadLatestBackup(storageParentPath);
+			}
+			else
+			{
+				LOG.info("Starting with local storage");
+			}
 
-            // don't send messages generated by starting the storage and storing the empty root
-            this.getClusterStorageBinaryDataDistributor().ignoreDistribution(true);
+			// don't send messages generated by starting the storage and storing the empty root
+			this.getClusterStorageBinaryDataDistributor().ignoreDistribution(true);
 
             this.getKafkaMessageInfoProvider().init();
 
-            final var embeddedStorageFoundation = this.getEmbeddedStorageFoundation();
-            // replace the storage live file provider from the provided embedded storage foundation
-            StorageConfiguration storageConfig = embeddedStorageFoundation.getConfiguration();
-            storageConfig = StorageConfiguration.Builder()
-                .setBackupSetup(storageConfig.backupSetup())
-                .setChannelCountProvider(storageConfig.channelCountProvider())
-                .setDataFileEvaluator(storageConfig.dataFileEvaluator())
-                .setEntityCacheEvaluator(storageConfig.entityCacheEvaluator())
-                .setHousekeepingController(storageConfig.housekeepingController())
-                .setStorageFileProvider(
-                    StorageLiveFileProvider.New(NioFileSystem.New().ensureDirectory(storageRootPath))
-                )
-                .createConfiguration();
-            embeddedStorageFoundation.setConfiguration(storageConfig);
-
-            final var dataDistributor = this.getClusterStorageBinaryDataDistributor();
-            DistributedStorage.configureWriting(embeddedStorageFoundation, dataDistributor);
-
-            embeddedStorageFoundation.setExceptionHandler((throwable, channel) ->
-            {
-                try
-                {
-                    StorageExceptionHandler.defaultHandleException(throwable, channel);
-                }
-                catch (final StorageException exception)
-                {
-                    GlobalErrorHandling.handleFatalError(exception);
-                }
-            });
-
-            final var embeddedStorageManager = embeddedStorageFoundation.start();
-
-            if (embeddedStorageManager.root() == null)
-            {
-                LOG.debug("Setting and storing new root from root supplier");
-                final var root = this.getRootSupplier().get();
-                if (root instanceof Lazy)
-                {
-                    embeddedStorageManager.setRoot(root);
-                }
-                else
-                {
-                    embeddedStorageManager.setRoot(Lazy.Reference(root));
-                }
-                embeddedStorageManager.storeRoot();
-            }
-
-            this.getClusterStorageBinaryDataDistributor().ignoreDistribution(false);
-
-            final var scheduler = this.getQuartzCronJobScheduler();
-
-            this.clusterStorageManager = ClusterStorageManager.New(
-                embeddedStorageManager,
-                () -> this.getStorageLimitCheckerQuartzCronJobManager().limitReached(),
-                scheduler::shutdown
-            );
-
-            this.getClusterStorageBinaryDataClient().start();
-
-            this.getStorageNodeHealthCheck().init();
-
-            this.clusterRequestController = ClusterRestRequestController.StorageNode(
-                this.getStorageNodeManager(),
-                this.getNodelibraryPropertiesProvider()
-            );
-
-            final var jobFactory = this.getQuartzCronJobJobFactory();
-
-            final var gcWorkaround = this.getGcWorkaroundQuartzCronJobManager();
-            jobFactory.setJobFactory(GcWorkaroundQuartzCronJob.class, gcWorkaround::create);
-
-            final var limitChecker = this.getStorageLimitCheckerQuartzCronJobManager();
-            jobFactory.setJobFactory(StorageLimitCheckerQuartzCronJob.class, limitChecker::create);
-
-            scheduler.setFactory(jobFactory);
-            scheduler.schedule(
-                JobBuilder.newJob(GcWorkaroundQuartzCronJob.class).withIdentity("GcWorkaround").build(),
-                // Once at the start of every hour
-                TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule("0 0 * * * ? *")).build()
-            );
-            scheduler.schedule(
-                JobBuilder.newJob(StorageLimitCheckerQuartzCronJob.class).withIdentity("StorageLimitChecker").build(),
-                TriggerBuilder.newTrigger()
-                    .withSchedule(
-                        SimpleScheduleBuilder.repeatMinutelyForever(
-                            this.getNodelibraryPropertiesProvider().storageLimitCheckerIntervalMinutes()
-                        )
-                    )
-
-                    .build()
-            );
-
-            scheduler.start();
-        }
-
-        protected void startMicroNode() throws NodelibraryException
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-        {
-            LOG.info("Starting micro cluster node");
-
-
-
-            // TODO: Hardcoded paths
-            final var storagePath = Paths.get("/storage/storage");
-            final EmbeddedStorageFoundation<?> embeddedStorageFoundation = this.getEmbeddedStorageFoundation();
-
-
-            // replace the storage live file provider from the provided embedded storage foundation
-            StorageConfiguration storageConfig = embeddedStorageFoundation.getConfiguration();
-            storageConfig = StorageConfiguration.Builder()
-                .setBackupSetup(storageConfig.backupSetup())
-                .setChannelCountProvider(storageConfig.channelCountProvider())
-                .setDataFileEvaluator(storageConfig.dataFileEvaluator())
-                .setEntityCacheEvaluator(storageConfig.entityCacheEvaluator())
-                .setHousekeepingController(storageConfig.housekeepingController())
-                .setStorageFileProvider(StorageLiveFileProvider.New(NioFileSystem.New().ensureDirectory(storagePath)))
-                .createConfiguration();
-            embeddedStorageFoundation.setConfiguration(storageConfig);
-
-
-
-
-            embeddedStorageFoundation.setExceptionHandler((throwable, channel) ->
-            {
-                try
-                {
-                    StorageExceptionHandler.defaultHandleException(throwable, channel);
-                }
-                catch (final StorageException exception)
-                {
-                    GlobalErrorHandling.handleFatalError(exception);
-                }
-            });
-
-            final var embeddedStorageManager = embeddedStorageFoundation.start();
-
-            if (embeddedStorageManager.root() == null)
-            {
-                final var root = this.rootSupplier.get();
-                if (root instanceof Lazy)
-                {
-                    embeddedStorageManager.setRoot(root);
-                }
-                else
-                {
-                    embeddedStorageManager.setRoot(Lazy.Reference(root));
-                }
-                embeddedStorageManager.storeRoot();
-            }
-
-            final var scheduler = this.getQuartzCronJobScheduler();
-
-            this.clusterStorageManager = ClusterStorageManager.New(
-                embeddedStorageManager,
-                () -> this.getStorageLimitCheckerQuartzCronJobManager().limitReached(),
-                scheduler::shutdown
-            );
-            this.clusterRequestController = ClusterRestRequestController.MicroNode(
-                this.getMicroNodeManager(),
-
-
-
-
-
-                this.getNodelibraryPropertiesProvider()
-            );
-
-            final var jobFactory = this.getQuartzCronJobJobFactory();
-
-
-
-
-            final var limitChecker = this.getStorageLimitCheckerQuartzCronJobManager();
-            jobFactory.setJobFactory(StorageLimitCheckerQuartzCronJob.class, limitChecker::create);
-
-            scheduler.setFactory(jobFactory);
-
-
-
-
-
-            scheduler.schedule(
-                JobBuilder.newJob(StorageLimitCheckerQuartzCronJob.class).withIdentity("StorageLimitChecker").build(),
-                TriggerBuilder.newTrigger()
-                    .withSchedule(
-                        SimpleScheduleBuilder.repeatMinutelyForever(
-                            this.getNodelibraryPropertiesProvider().storageLimitCheckerIntervalMinutes()
-                        )
-                    )
-                    .startNow()
-                    .build()
-            );
-
-            scheduler.start();
-        }
-
-        protected void startDevNode() throws NodelibraryException
-        {
-            LOG.info("Starting dev cluster node");
-            final var storage = this.getEmbeddedStorageFoundation().start();
-            if (storage.root() == null)
-            {
-                final var root = this.getRootSupplier().get();
-                if (root instanceof Lazy)
-                {
-                    storage.setRoot(root);
-                }
-                else
-                {
-                    storage.setRoot(Lazy.Reference(root));
-                }
-                storage.storeRoot();
-            }
-
-            this.clusterStorageManager = ClusterStorageManager.Wrapper(
-                storage,
-                ClusterStorageManager.ShutdownCallback.NoOp()
-            );
-            this.clusterRequestController = ClusterRestRequestController.DevNode();
-        }
-
-        private void deleteDirectory(final Path path)
-        {
-            if (!Files.exists(path))
-            {
-                return;
-            }
-
-            LOG.info("Deleting files at {}", path);
-
-            try (final var directories = Files.walk(path))
-            {
-                directories.sorted(Comparator.reverseOrder()).forEach(f ->
-                {
-                    try
-                    {
-                        Files.delete(f);
-                    }
-                    catch (final IOException e)
-                    {
-                        throw new NodelibraryException("Failed to delete file at " + f.toString(), e);
-                    }
-                });
-            }
-            catch (final IOException e) // thrown by Files.walk(Path)
-            {
-                throw new NodelibraryException("Failed to walk files at " + path);
-            }
-        }
-    }
+			final var embeddedStorageFoundation = this.getEmbeddedStorageFoundation();
+			// replace the storage live file provider from the provided embedded storage foundation
+			StorageConfiguration storageConfig = embeddedStorageFoundation.getConfiguration();
+			storageConfig = StorageConfiguration.Builder()
+				.setBackupSetup(storageConfig.backupSetup())
+				.setChannelCountProvider(storageConfig.channelCountProvider())
+				.setDataFileEvaluator(storageConfig.dataFileEvaluator())
+				.setEntityCacheEvaluator(storageConfig.entityCacheEvaluator())
+				.setHousekeepingController(storageConfig.housekeepingController())
+				.setStorageFileProvider(
+					StorageLiveFileProvider.New(NioFileSystem.New().ensureDirectory(storageRootPath))
+				)
+				.createConfiguration();
+			embeddedStorageFoundation.setConfiguration(storageConfig);
+
+			final var dataDistributor = this.getClusterStorageBinaryDataDistributor();
+			DistributedStorage.configureWriting(embeddedStorageFoundation, dataDistributor);
+
+			embeddedStorageFoundation.setExceptionHandler((throwable, channel) ->
+			{
+				try
+				{
+					StorageExceptionHandler.defaultHandleException(throwable, channel);
+				}
+				catch (final StorageException exception)
+				{
+					GlobalErrorHandling.handleFatalError(exception);
+				}
+			});
+
+			final var embeddedStorageManager = embeddedStorageFoundation.start();
+
+			if (embeddedStorageManager.root() == null)
+			{
+				LOG.debug("Setting and storing new root from root supplier");
+				final var root = this.getRootSupplier().get();
+				if (root instanceof Lazy)
+				{
+					embeddedStorageManager.setRoot(root);
+				}
+				else
+				{
+					embeddedStorageManager.setRoot(Lazy.Reference(root));
+				}
+				embeddedStorageManager.storeRoot();
+			}
+
+			this.getClusterStorageBinaryDataDistributor().ignoreDistribution(false);
+
+			final var scheduler = this.getQuartzCronJobScheduler();
+
+			this.clusterStorageManager = ClusterStorageManager.New(
+				embeddedStorageManager,
+				() -> this.getStorageLimitCheckerQuartzCronJobManager().limitReached(),
+				scheduler::shutdown
+			);
+
+			this.getClusterStorageBinaryDataClient().start();
+
+			this.getStorageNodeHealthCheck().init();
+
+			this.clusterRequestController = ClusterRestRequestController.StorageNode(
+				this.getStorageNodeManager(),
+				this.getNodelibraryPropertiesProvider()
+			);
+
+			final var jobFactory = this.getQuartzCronJobJobFactory();
+
+			final var gcWorkaround = this.getGcWorkaroundQuartzCronJobManager();
+			jobFactory.setJobFactory(GcWorkaroundQuartzCronJob.class, gcWorkaround::create);
+
+			final var limitChecker = this.getStorageLimitCheckerQuartzCronJobManager();
+			jobFactory.setJobFactory(StorageLimitCheckerQuartzCronJob.class, limitChecker::create);
+
+			scheduler.setFactory(jobFactory);
+			scheduler.schedule(
+				JobBuilder.newJob(GcWorkaroundQuartzCronJob.class).withIdentity("GcWorkaround").build(),
+				// Once at the start of every hour
+				TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule("0 0 * * * ? *")).build()
+			);
+			scheduler.schedule(
+				JobBuilder.newJob(StorageLimitCheckerQuartzCronJob.class).withIdentity("StorageLimitChecker").build(),
+				TriggerBuilder.newTrigger()
+					.withSchedule(
+						SimpleScheduleBuilder.repeatMinutelyForever(
+							this.getNodelibraryPropertiesProvider().storageLimitCheckerIntervalMinutes()
+						)
+					)
+
+					.build()
+			);
+
+			scheduler.start();
+		}
+
+		protected void startMicroNode() throws NodelibraryException
+
+		{
+			LOG.info("Starting micro cluster node");
+
+			// TODO: Hardcoded paths
+			final var storagePath = Paths.get("/storage/storage");
+			final EmbeddedStorageFoundation<?> embeddedStorageFoundation = this.getEmbeddedStorageFoundation();
+
+			// replace the storage live file provider from the provided embedded storage foundation
+			StorageConfiguration storageConfig = embeddedStorageFoundation.getConfiguration();
+			storageConfig = StorageConfiguration.Builder()
+				.setBackupSetup(storageConfig.backupSetup())
+				.setChannelCountProvider(storageConfig.channelCountProvider())
+				.setDataFileEvaluator(storageConfig.dataFileEvaluator())
+				.setEntityCacheEvaluator(storageConfig.entityCacheEvaluator())
+				.setHousekeepingController(storageConfig.housekeepingController())
+				.setStorageFileProvider(StorageLiveFileProvider.New(NioFileSystem.New().ensureDirectory(storagePath)))
+				.createConfiguration();
+			embeddedStorageFoundation.setConfiguration(storageConfig);
+
+			embeddedStorageFoundation.setExceptionHandler((throwable, channel) ->
+			{
+				try
+				{
+					StorageExceptionHandler.defaultHandleException(throwable, channel);
+				}
+				catch (final StorageException exception)
+				{
+					GlobalErrorHandling.handleFatalError(exception);
+				}
+			});
+
+			final var embeddedStorageManager = embeddedStorageFoundation.start();
+
+			if (embeddedStorageManager.root() == null)
+			{
+				final var root = this.rootSupplier.get();
+				if (root instanceof Lazy)
+				{
+					embeddedStorageManager.setRoot(root);
+				}
+				else
+				{
+					embeddedStorageManager.setRoot(Lazy.Reference(root));
+				}
+				embeddedStorageManager.storeRoot();
+			}
+
+			final var scheduler = this.getQuartzCronJobScheduler();
+
+			this.clusterStorageManager = ClusterStorageManager.New(
+				embeddedStorageManager,
+				() -> this.getStorageLimitCheckerQuartzCronJobManager().limitReached(),
+				scheduler::shutdown
+			);
+			this.clusterRequestController = ClusterRestRequestController.MicroNode(
+				this.getMicroNodeManager(),
+
+				this.getNodelibraryPropertiesProvider()
+			);
+
+			final var jobFactory = this.getQuartzCronJobJobFactory();
+
+			final var limitChecker = this.getStorageLimitCheckerQuartzCronJobManager();
+			jobFactory.setJobFactory(StorageLimitCheckerQuartzCronJob.class, limitChecker::create);
+
+			scheduler.setFactory(jobFactory);
+
+			scheduler.schedule(
+				JobBuilder.newJob(StorageLimitCheckerQuartzCronJob.class).withIdentity("StorageLimitChecker").build(),
+				TriggerBuilder.newTrigger()
+					.withSchedule(
+						SimpleScheduleBuilder.repeatMinutelyForever(
+							this.getNodelibraryPropertiesProvider().storageLimitCheckerIntervalMinutes()
+						)
+					)
+					.startNow()
+					.build()
+			);
+
+			scheduler.start();
+		}
+
+		protected void startDevNode() throws NodelibraryException
+		{
+			LOG.info("Starting dev cluster node");
+			final var storage = this.getEmbeddedStorageFoundation().start();
+			if (storage.root() == null)
+			{
+				final var root = this.getRootSupplier().get();
+				if (root instanceof Lazy)
+				{
+					storage.setRoot(root);
+				}
+				else
+				{
+					storage.setRoot(Lazy.Reference(root));
+				}
+				storage.storeRoot();
+			}
+
+			this.clusterStorageManager = ClusterStorageManager.Wrapper(
+				storage,
+				ClusterStorageManager.ShutdownCallback.NoOp()
+			);
+			this.clusterRequestController = ClusterRestRequestController.DevNode();
+		}
+
+		private void deleteDirectory(final Path path)
+		{
+			if (!Files.exists(path))
+			{
+				return;
+			}
+
+			LOG.info("Deleting files at {}", path);
+
+			try (final var directories = Files.walk(path))
+			{
+				directories.sorted(Comparator.reverseOrder()).forEach(f ->
+				{
+					try
+					{
+						Files.delete(f);
+					}
+					catch (final IOException e)
+					{
+						throw new NodelibraryException("Failed to delete file at " + f.toString(), e);
+					}
+				});
+			}
+			catch (final IOException e) // thrown by Files.walk(Path)
+			{
+				throw new NodelibraryException("Failed to walk files at " + path);
+			}
+		}
+	}
 }

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/NodelibraryPropertiesProvider.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/NodelibraryPropertiesProvider.java
@@ -16,229 +16,238 @@ package org.eclipse.datagrid.cluster.nodelibrary.types;
 
 public interface NodelibraryPropertiesProvider
 {
-    boolean secureKafka();
+	boolean secureKafka();
 
-    String kafkaBootstrapServers();
+	String kafkaBootstrapServers();
 
-    String kafkaTopicName();
+	String kafkaTopicName();
 
-    boolean isBackupNode();
+	boolean isBackupNode();
 
-    Integer keptBackupsCount();
+	Integer keptBackupsCount();
 
-    BackupTarget backupTarget();
+	BackupTarget backupTarget();
 
-    Integer backupIntervalMinutes();
+	Integer backupIntervalMinutes();
 
-    String microstreamPath();
+	String microstreamPath();
 
-    String backupNodeServiceUrl();
+	String backupNodeServiceUrl();
 
-    String backupProxyServiceUrl();
+	String backupProxyServiceUrl();
 
-    Integer storageLimitCheckerIntervalMinutes();
+	Integer storageLimitCheckerIntervalMinutes();
 
-    Double storageLimitCheckerPercent();
+	Double storageLimitCheckerPercent();
 
-    Integer storageLimitGB();
+	Integer storageLimitGB();
 
-    boolean isMicro();
+	boolean isMicro();
 
-    String kafkaUsername();
+	String kafkaUsername();
 
-    String kafkaPassword();
+	String kafkaPassword();
 
-    String myPodName();
+	String myPodName();
 
-    String myNamespace();
+	String myNamespace();
 
-    boolean isProdMode();
+	boolean isProdMode();
 
-    Long dataMergerTimeoutMs();
+	Long dataMergerTimeoutMs();
 
-    static NodelibraryPropertiesProvider Env()
-    {
-        return new Env();
-    }
+	Long dataMergerCachedDataLimit();
 
-    class Env implements NodelibraryPropertiesProvider
-    {
-        public static final class EnvKeys
-        {
-            public static final String SECURE_KAFKA = "MSCNL_SECURE_KAFKA";
-            public static final String KAFKA_BOOTSTRAP_SERVERS = "KAFKA_BOOTSTRAP_SERVERS";
-            public static final String KAFKA_TOPIC_NAME = "MSCNL_KAFKA_TOPIC_NAME";
-            public static final String IS_BACKUP_NODE = "IS_BACKUP_NODE";
-            public static final String BACKUP_TARGET = "BACKUP_TARGET";
-            public static final String KEPT_BACKUPS_COUNT = "KEPT_BACKUPS_COUNT";
-            public static final String BACKUP_INTERVAL_MINUTES = "BACKUP_INTERVAL_MINUTES";
-            public static final String MICROSTREAM_PATH = "MICROSTREAM_PATH";
-            public static final String BACKUP_NODE_SERVICE_URL = "BACKUP_NODE_SERVICE_URL";
-            public static final String BACKUP_PROXY_SERVICE_URL = "BACKUP_PROXY_SERVICE_URL";
-            public static final String STORAGE_LIMIT_CHECKER_INTERVAL_MINUTES =
-                "STORAGE_LIMIT_CHECKER_INTERVAL_MINUTES";
-            public static final String STORAGE_LIMIT_CHECKER_PERCENT = "STORAGE_LIMIT_CHECKER_PERCENT";
-            public static final String STORAGE_LIMIT_GB = "STORAGE_LIMIT_GB";
-            public static final String IS_MICRO = "MSCNL_IS_MICRO";
-            public static final String KAFKA_USERNAME = "MSCNL_KAFKA_USERNAME";
-            public static final String KAFKA_PASSWORD = "MSCNL_KAFKA_PASSWORD";
-            public static final String MY_POD_NAME = "MY_POD_NAME";
-            public static final String MY_NAMESPACE = "MY_NAMESPACE";
-            public static final String IS_PROD_MODE = "MSCNL_PROD_MODE";
-            public static final String DATA_MERGER_TIMEOUT_MS = "MSCNL_DATA_MERGER_TIMEOUT";
+	static NodelibraryPropertiesProvider Env()
+	{
+		return new Env();
+	}
 
-            private EnvKeys()
-            {
-            }
-        }
+	class Env implements NodelibraryPropertiesProvider
+	{
+		public static final class EnvKeys
+		{
+			public static final String SECURE_KAFKA = "MSCNL_SECURE_KAFKA";
+			public static final String KAFKA_BOOTSTRAP_SERVERS = "KAFKA_BOOTSTRAP_SERVERS";
+			public static final String KAFKA_TOPIC_NAME = "MSCNL_KAFKA_TOPIC_NAME";
+			public static final String IS_BACKUP_NODE = "IS_BACKUP_NODE";
+			public static final String BACKUP_TARGET = "BACKUP_TARGET";
+			public static final String KEPT_BACKUPS_COUNT = "KEPT_BACKUPS_COUNT";
+			public static final String BACKUP_INTERVAL_MINUTES = "BACKUP_INTERVAL_MINUTES";
+			public static final String MICROSTREAM_PATH = "MICROSTREAM_PATH";
+			public static final String BACKUP_NODE_SERVICE_URL = "BACKUP_NODE_SERVICE_URL";
+			public static final String BACKUP_PROXY_SERVICE_URL = "BACKUP_PROXY_SERVICE_URL";
+			public static final String STORAGE_LIMIT_CHECKER_INTERVAL_MINUTES =
+				"STORAGE_LIMIT_CHECKER_INTERVAL_MINUTES";
+			public static final String STORAGE_LIMIT_CHECKER_PERCENT = "STORAGE_LIMIT_CHECKER_PERCENT";
+			public static final String STORAGE_LIMIT_GB = "STORAGE_LIMIT_GB";
+			public static final String IS_MICRO = "MSCNL_IS_MICRO";
+			public static final String KAFKA_USERNAME = "MSCNL_KAFKA_USERNAME";
+			public static final String KAFKA_PASSWORD = "MSCNL_KAFKA_PASSWORD";
+			public static final String MY_POD_NAME = "MY_POD_NAME";
+			public static final String MY_NAMESPACE = "MY_NAMESPACE";
+			public static final String IS_PROD_MODE = "MSCNL_PROD_MODE";
+			public static final String DATA_MERGER_TIMEOUT_MS = "MSCNL_DATA_MERGER_TIMEOUT";
+			public static final String DATA_MERGER_LIMIT = "MSCNL_DATA_MERGER_LIMIT";
 
-        @Override
-        public boolean secureKafka()
-        {
-            return this.envBoolean(EnvKeys.SECURE_KAFKA);
-        }
+			private EnvKeys()
+			{
+			}
+		}
 
-        @Override
-        public String kafkaBootstrapServers()
-        {
-            return this.envString(EnvKeys.KAFKA_BOOTSTRAP_SERVERS);
-        }
+		@Override
+		public boolean secureKafka()
+		{
+			return this.envBoolean(EnvKeys.SECURE_KAFKA);
+		}
 
-        @Override
-        public String kafkaTopicName()
-        {
-            return this.envString(EnvKeys.KAFKA_TOPIC_NAME);
-        }
+		@Override
+		public String kafkaBootstrapServers()
+		{
+			return this.envString(EnvKeys.KAFKA_BOOTSTRAP_SERVERS);
+		}
 
-        @Override
-        public boolean isBackupNode()
-        {
-            return this.envBoolean(EnvKeys.IS_BACKUP_NODE);
-        }
+		@Override
+		public String kafkaTopicName()
+		{
+			return this.envString(EnvKeys.KAFKA_TOPIC_NAME);
+		}
 
-        @Override
-        public BackupTarget backupTarget()
-        {
-            return BackupTarget.parse(this.envString(EnvKeys.BACKUP_TARGET));
-        }
+		@Override
+		public boolean isBackupNode()
+		{
+			return this.envBoolean(EnvKeys.IS_BACKUP_NODE);
+		}
 
-        @Override
-        public Integer keptBackupsCount()
-        {
-            return this.envInteger(EnvKeys.KEPT_BACKUPS_COUNT);
-        }
+		@Override
+		public BackupTarget backupTarget()
+		{
+			return BackupTarget.parse(this.envString(EnvKeys.BACKUP_TARGET));
+		}
 
-        @Override
-        public Integer backupIntervalMinutes()
-        {
-            return this.envInteger(EnvKeys.BACKUP_INTERVAL_MINUTES);
-        }
+		@Override
+		public Integer keptBackupsCount()
+		{
+			return this.envInteger(EnvKeys.KEPT_BACKUPS_COUNT);
+		}
 
-        @Override
-        public String microstreamPath()
-        {
-            return this.envString(EnvKeys.MICROSTREAM_PATH);
-        }
+		@Override
+		public Integer backupIntervalMinutes()
+		{
+			return this.envInteger(EnvKeys.BACKUP_INTERVAL_MINUTES);
+		}
 
-        @Override
-        public String backupNodeServiceUrl()
-        {
-            return this.envString(EnvKeys.BACKUP_NODE_SERVICE_URL);
-        }
+		@Override
+		public String microstreamPath()
+		{
+			return this.envString(EnvKeys.MICROSTREAM_PATH);
+		}
 
-        @Override
-        public String backupProxyServiceUrl()
-        {
-            return this.envString(EnvKeys.BACKUP_PROXY_SERVICE_URL);
-        }
+		@Override
+		public String backupNodeServiceUrl()
+		{
+			return this.envString(EnvKeys.BACKUP_NODE_SERVICE_URL);
+		}
 
-        @Override
-        public Integer storageLimitCheckerIntervalMinutes()
-        {
-            return this.envInteger(EnvKeys.STORAGE_LIMIT_CHECKER_INTERVAL_MINUTES);
-        }
+		@Override
+		public String backupProxyServiceUrl()
+		{
+			return this.envString(EnvKeys.BACKUP_PROXY_SERVICE_URL);
+		}
 
-        @Override
-        public Double storageLimitCheckerPercent()
-        {
-            return this.envDouble(EnvKeys.STORAGE_LIMIT_CHECKER_PERCENT);
-        }
+		@Override
+		public Integer storageLimitCheckerIntervalMinutes()
+		{
+			return this.envInteger(EnvKeys.STORAGE_LIMIT_CHECKER_INTERVAL_MINUTES);
+		}
 
-        @Override
-        public Integer storageLimitGB()
-        {
-            // TODO: Change behaviour to set an integer instead of a formatted string like this
-            return Integer.parseInt(this.envString(EnvKeys.STORAGE_LIMIT_GB).replace("G", ""));
-        }
+		@Override
+		public Double storageLimitCheckerPercent()
+		{
+			return this.envDouble(EnvKeys.STORAGE_LIMIT_CHECKER_PERCENT);
+		}
 
-        @Override
-        public boolean isMicro()
-        {
-            return this.envBoolean(EnvKeys.IS_MICRO);
-        }
+		@Override
+		public Integer storageLimitGB()
+		{
+			// TODO: Change behaviour to set an integer instead of a formatted string like this
+			return Integer.parseInt(this.envString(EnvKeys.STORAGE_LIMIT_GB).replace("G", ""));
+		}
 
-        @Override
-        public String kafkaUsername()
-        {
-            return this.envString(EnvKeys.KAFKA_USERNAME);
-        }
+		@Override
+		public boolean isMicro()
+		{
+			return this.envBoolean(EnvKeys.IS_MICRO);
+		}
 
-        @Override
-        public String kafkaPassword()
-        {
-            return this.envString(EnvKeys.KAFKA_PASSWORD);
-        }
+		@Override
+		public String kafkaUsername()
+		{
+			return this.envString(EnvKeys.KAFKA_USERNAME);
+		}
 
-        @Override
-        public String myPodName()
-        {
-            return this.envString(EnvKeys.MY_POD_NAME);
-        }
+		@Override
+		public String kafkaPassword()
+		{
+			return this.envString(EnvKeys.KAFKA_PASSWORD);
+		}
 
-        @Override
-        public String myNamespace()
-        {
-            return this.envString(EnvKeys.MY_NAMESPACE);
-        }
+		@Override
+		public String myPodName()
+		{
+			return this.envString(EnvKeys.MY_POD_NAME);
+		}
 
-        @Override
-        public boolean isProdMode()
-        {
-            return this.envBoolean(EnvKeys.IS_PROD_MODE);
-        }
+		@Override
+		public String myNamespace()
+		{
+			return this.envString(EnvKeys.MY_NAMESPACE);
+		}
 
-        @Override
-        public Long dataMergerTimeoutMs()
-        {
-            return this.envLong(EnvKeys.DATA_MERGER_TIMEOUT_MS);
-        }
+		@Override
+		public boolean isProdMode()
+		{
+			return this.envBoolean(EnvKeys.IS_PROD_MODE);
+		}
 
-        private Integer envInteger(final String envkey)
-        {
-            final String env = this.envString(envkey);
-            return env == null ? null : Integer.parseInt(env);
-        }
+		@Override
+		public Long dataMergerTimeoutMs()
+		{
+			return this.envLong(EnvKeys.DATA_MERGER_TIMEOUT_MS);
+		}
 
-        private Long envLong(final String envkey)
-        {
-            final String env = this.envString(envkey);
-            return env == null ? null : Long.parseLong(env);
-        }
+		@Override
+		public Long dataMergerCachedDataLimit()
+		{
+			return this.envLong(EnvKeys.DATA_MERGER_LIMIT);
+		}
 
-        private Double envDouble(final String envkey)
-        {
-            final String env = this.envString(envkey);
-            return env == null ? null : Double.parseDouble(env);
-        }
+		private Integer envInteger(final String envkey)
+		{
+			final String env = this.envString(envkey);
+			return env == null ? null : Integer.parseInt(env);
+		}
 
-        private boolean envBoolean(final String envkey)
-        {
-            return Boolean.parseBoolean(this.envString(envkey));
-        }
+		private Long envLong(final String envkey)
+		{
+			final String env = this.envString(envkey);
+			return env == null ? null : Long.parseLong(env);
+		}
 
-        private String envString(final String envkey)
-        {
-            return System.getenv(envkey);
-        }
-    }
+		private Double envDouble(final String envkey)
+		{
+			final String env = this.envString(envkey);
+			return env == null ? null : Double.parseDouble(env);
+		}
+
+		private boolean envBoolean(final String envkey)
+		{
+			return Boolean.parseBoolean(this.envString(envkey));
+		}
+
+		private String envString(final String envkey)
+		{
+			return System.getenv(envkey);
+		}
+	}
 }


### PR DESCRIPTION
If not done on heavy writes the cached data will increase more and more the more data is cached -> the longer the graph update takes -> the more data cached etc.
This will stop the data client from reading more until the limit is resolved