### PR TITLE
Update EclipseStore and Serializer dependencies to version 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 		<maven.compiler.release>17</maven.compiler.release>
 		<maven.version.minimum>3.8.1</maven.version.minimum>
 		<maven.java.version.minimum>17</maven.java.version.minimum>
-        <eclipse-store.version>4.0.0-SNAPSHOT</eclipse-store.version>
-        <eclipse-serializer.version>4.0.0-SNAPSHOT</eclipse-serializer.version>
+        <eclipse-store.version>3.1.0</eclipse-store.version>
+        <eclipse-serializer.version>3.1.0</eclipse-serializer.version>
 		<license.inceptionYear>2025</license.inceptionYear>
 		<license.licenseName>epl_only_v2</license.licenseName>
 		<license.licenceFile>${basedir}/LICENSE</license.licenceFile>


### PR DESCRIPTION
This pull request updates the following dependencies in the `pom.xml` file:
- EclipseStore: Updated to version 3.1.0
- Serializer: Updated to version 3.1.0

These changes ensure compatibility with the latest improvements and fixes available in these dependencies.
