### PR TITLE
Fix KafkaProducer.send() future .get() not called

### DIFF
--- a/cache/clustered/clustered/pom.xml
+++ b/cache/clustered/clustered/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>4.1.1</version>
+            <version>4.2.0</version>
 		</dependency>
     </dependencies>
 

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
@@ -14,19 +14,15 @@ package org.eclipse.datagrid.cluster.nodelibrary.types;
  * #L%
  */
 
-
-import static org.apache.kafka.clients.producer.ProducerConfig.COMPRESSION_TYPE_CONFIG;
-import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
-import static org.eclipse.serializer.chars.XChars.notEmpty;
-
 import java.nio.ByteBuffer;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -39,6 +35,8 @@ import org.eclipse.serializer.persistence.binary.types.ChunksWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.kafka.clients.producer.ProducerConfig.*;
+import static org.eclipse.serializer.chars.XChars.notEmpty;
 import static org.eclipse.serializer.util.X.notNull;
 
 public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorageBinaryDataDistributor
@@ -166,7 +164,27 @@ public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorage
 				{
 					LOG.debug("Sending kafka packet at message index {}", this.messageIndex);
 				}
-				this.producer.send(kafkaRecord);
+
+				try
+				{
+					this.producer.send(kafkaRecord).get();
+				}
+				catch (final InterruptedException e)
+				{
+					throw new InterruptException("Interrupted while sending the Kafka record", e);
+				}
+				catch (final ExecutionException e)
+				{
+					final var cause = e.getCause();
+					if (cause instanceof final RuntimeException rte)
+					{
+						throw rte;
+					}
+					else
+					{
+						throw new RuntimeException(cause);
+					}
+				}
 
 				packetIndex++;
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<maven.compiler.release>17</maven.compiler.release>
 		<maven.version.minimum>3.8.1</maven.version.minimum>
 		<maven.java.version.minimum>17</maven.java.version.minimum>
-        <eclipse-store.version>3.1.0</eclipse-store.version>
+		<eclipse-store.version>4.0.0-beta3</eclipse-store.version>
         <eclipse-serializer.version>3.1.0</eclipse-serializer.version>
 		<license.inceptionYear>2025</license.inceptionYear>
 		<license.licenseName>epl_only_v2</license.licenseName>

--- a/storage/distributed/kafka/pom.xml
+++ b/storage/distributed/kafka/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>4.0.0</version>
+			<version>4.2.0</version>
 		</dependency>
 	</dependencies>
 

--- a/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDataDistributorKafka.java
+++ b/storage/distributed/kafka/src/main/java/org/eclipse/datagrid/storage/distributed/kafka/types/StorageBinaryDataDistributorKafka.java
@@ -14,28 +14,28 @@ package org.eclipse.datagrid.storage.distributed.kafka.types;
  * #L%
  */
 
-
-import static org.eclipse.serializer.chars.XChars.notEmpty;
-import static org.eclipse.serializer.util.X.notNull;
-
 import java.nio.ByteBuffer;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataDistributor;
+import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataMessage.MessageType;
 import org.eclipse.serializer.collections.BulkList;
 import org.eclipse.serializer.collections.types.XList;
 import org.eclipse.serializer.memory.XMemory;
 import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.binary.types.ChunksWrapper;
 
-import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataDistributor;
-import org.eclipse.datagrid.storage.distributed.types.StorageBinaryDataMessage.MessageType;
+import static org.eclipse.serializer.chars.XChars.notEmpty;
+import static org.eclipse.serializer.util.X.notNull;
 
 public interface StorageBinaryDataDistributorKafka
 	extends
@@ -156,7 +156,27 @@ public interface StorageBinaryDataDistributorKafka
 					packetIndex,
 					packetCount
 				);
-				producer.send(record);
+
+				try
+				{
+					producer.send(record).get();
+				}
+				catch (final InterruptedException e)
+				{
+					throw new InterruptException("Interrupted while sending the Kafka record", e);
+				}
+				catch (final ExecutionException e)
+				{
+					final var cause = e.getCause();
+					if (cause instanceof final RuntimeException rte)
+					{
+						throw rte;
+					}
+					else
+					{
+						throw new RuntimeException(cause);
+					}
+				}
 
 				packetIndex++;
 			}


### PR DESCRIPTION
To ensure the message being acknowledged by the Kafka server for the Sync implementation we need to wait on the future returned by the send() method.

Also updated the kafka-clients dependency to fix some transitive vulnerabilities & use the latest eclipse-store version for the required Cache.putSilent() method.