### PR TITLE
Call .get() on returned future

### DIFF
--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
@@ -168,10 +168,6 @@ public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorage
 				{
 					this.producer.send(kafkaRecord).get();
 				}
-				catch (final InterruptedException e)
-				{
-					throw e;
-				}
 				catch (final ExecutionException e)
 				{
 					// Kafka only throws RuntimeException's

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -106,7 +105,7 @@ public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorage
 			}
 		}
 
-		private void executeDistribution(final MessageType messageType, final Binary data)
+		private void executeDistribution(final MessageType messageType, final Binary data) throws InterruptedException
 		{
 			final ByteBuffer[] buffers = this.allBuffers(data);
 			int messageSize = 0;
@@ -171,8 +170,7 @@ public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorage
 				}
 				catch (final InterruptedException e)
 				{
-					Thread.currentThread().interrupt();
-					throw new InterruptException(e);
+					throw e;
 				}
 				catch (final ExecutionException e)
 				{

--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/ClusterStorageBinaryDataDistributorKafka.java
@@ -14,19 +14,15 @@ package org.eclipse.datagrid.cluster.nodelibrary.types;
  * #L%
  */
 
-
-import static org.apache.kafka.clients.producer.ProducerConfig.COMPRESSION_TYPE_CONFIG;
-import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
-import static org.eclipse.serializer.chars.XChars.notEmpty;
-
 import java.nio.ByteBuffer;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -39,6 +35,8 @@ import org.eclipse.serializer.persistence.binary.types.ChunksWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.kafka.clients.producer.ProducerConfig.*;
+import static org.eclipse.serializer.chars.XChars.notEmpty;
 import static org.eclipse.serializer.util.X.notNull;
 
 public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorageBinaryDataDistributor
@@ -166,7 +164,21 @@ public interface ClusterStorageBinaryDataDistributorKafka extends ClusterStorage
 				{
 					LOG.debug("Sending kafka packet at message index {}", this.messageIndex);
 				}
-				this.producer.send(kafkaRecord);
+
+				try
+				{
+					this.producer.send(kafkaRecord).get();
+				}
+				catch (final InterruptedException e)
+				{
+					Thread.currentThread().interrupt();
+					throw new InterruptException(e);
+				}
+				catch (final ExecutionException e)
+				{
+					// Kafka only throws RuntimeException's
+					throw (RuntimeException)e.getCause();
+				}
 
 				packetIndex++;
 			}


### PR DESCRIPTION
To ensure the message being acknowledged by the Kafka server for the Sync implementation we need to wait on the future returned by the send() method.