### PR TITLE
fix: only delete old records with automatic backups

### DIFF
--- a/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/StorageBackupManager.java
+++ b/cluster/nodelibrary/nodelibrary/src/main/java/org/eclipse/datagrid/cluster/nodelibrary/types/StorageBackupManager.java
@@ -137,9 +137,12 @@ public interface StorageBackupManager
             {
                 this.backend.createAndUploadBackup(this.storageConnection, this.messageInfoSupplier.get(), newBackup);
 
-                // delete up to the previous backup to save on Kafka log storage
-                this.backend.getMessageInfoFromPreviousBackup(1)
-                    .ifPresent(info -> this.kafkaRecordDeleter.deleteUntilOffsets(info.kafkaPartitionOffsets()));
+                if (!useManualSlot)
+                {
+                    // delete up to the previous backup to save on Kafka log storage
+                    this.backend.getMessageInfoFromPreviousBackup(1)
+                        .ifPresent(info -> this.kafkaRecordDeleter.deleteUntilOffsets(info.kafkaPartitionOffsets()));
+                }
             }
             finally
             {


### PR DESCRIPTION
Prevent triggering the record deletion when a manual backup request comes from the user.